### PR TITLE
배포환경 에러 시 디스코드 알림 추가

### DIFF
--- a/src/main/java/store/piku/back/global/error/ErrorCode.java
+++ b/src/main/java/store/piku/back/global/error/ErrorCode.java
@@ -6,8 +6,10 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
-    DIARY_NOT_FOUND(404, "해당 일기 목록이 존재하지 않습니다.");
+    DIARY_NOT_FOUND(404, "해당 일기 목록이 존재하지 않습니다."),
 
-    private final int code;
+    INTERNAL_SERVER_ERROR(500, "서버에 오류가 발생했습니다.");
+
+    private final int status;
     private final String message;
 }

--- a/src/main/java/store/piku/back/global/error/ErrorResponse.java
+++ b/src/main/java/store/piku/back/global/error/ErrorResponse.java
@@ -1,0 +1,14 @@
+package store.piku.back.global.error;
+
+import lombok.Getter;
+
+@Getter
+public class ErrorResponse {
+    private final int status;
+    private final String message;
+
+    public ErrorResponse(int status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+} 

--- a/src/main/java/store/piku/back/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/store/piku/back/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,43 @@
+package store.piku.back.global.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import store.piku.back.global.error.ErrorCode;
+import store.piku.back.global.error.ErrorResponse;
+import store.piku.back.global.notification.DiscordWebhookService;
+
+import java.util.Optional;
+
+@Slf4j
+@RestControllerAdvice
+@RequiredArgsConstructor
+public class GlobalExceptionHandler {
+
+    private final Optional<DiscordWebhookService> discordWebhookService;
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+        log.error("BusinessException occurred: {}", e.getMessage(), e);
+        ErrorCode errorCode = e.getErrorCode();
+        ErrorResponse response = new ErrorResponse(errorCode.getStatus(), errorCode.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.valueOf(errorCode.getStatus()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ResponseEntity<ErrorResponse> handleException(Exception e, HttpServletRequest request) {
+        log.error("Unhandled Exception occurred: {}", e.getMessage(), e);
+
+        discordWebhookService.ifPresent(service -> service.sendExceptionNotification(e, request));
+
+        ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
+        ErrorResponse response = new ErrorResponse(errorCode.getStatus(), errorCode.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/store/piku/back/global/notification/DiscordWebhookService.java
+++ b/src/main/java/store/piku/back/global/notification/DiscordWebhookService.java
@@ -1,0 +1,105 @@
+package store.piku.back.global.notification;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import store.piku.back.global.notification.dto.DiscordEmbed;
+import store.piku.back.global.notification.dto.DiscordMessage;
+import store.piku.back.global.notification.dto.EmbedField;
+
+import java.awt.*;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+@Profile("prod")
+@RequiredArgsConstructor
+public class DiscordWebhookService {
+
+    @Value("${discord.webhook.url}")
+    private String webhookUrl;
+
+    private final WebClient.Builder webClientBuilder;
+
+    public void sendExceptionNotification(Exception e, HttpServletRequest request) {
+        log.info("Sending exception notification to Discord...");
+
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        e.printStackTrace(pw);
+        final DiscordMessage discordMessage = getDiscordMessage(e, request, sw);
+
+        webClientBuilder.build()
+            .post()
+            .uri(webhookUrl)
+            .bodyValue(discordMessage)
+            .retrieve()
+            .bodyToMono(Void.class)
+            .doOnSuccess(v -> log.info("Successfully sent exception notification to Discord."))
+            .doOnError(error -> log.error("Failed to send exception notification to Discord.", error))
+            .subscribe();
+    }
+
+    private static DiscordMessage getDiscordMessage(Exception e, HttpServletRequest request, StringWriter sw) {
+        String stackTrace = sw.toString();
+        if (stackTrace.length() > 500) {
+            stackTrace = stackTrace.substring(0, 250) + "\n...\n...\n" + stackTrace.substring(stackTrace.length() - 250);
+        }
+        
+        String userAgent = request.getHeader("User-Agent");
+        if (userAgent == null) {
+            userAgent = "N/A";
+        }
+
+        List<EmbedField> fields = new ArrayList<>(List.of(
+                new EmbedField("Request-URI", request.getRequestURI(), false),
+                new EmbedField("Request-Method", request.getMethod(), false),
+                new EmbedField("Client-IP", getClientIp(request), true),
+                new EmbedField("User-Agent", userAgent, true),
+                new EmbedField("Error-Message", e.getMessage() != null ? e.getMessage() : "N/A", false)
+        ));
+        fields.add(new EmbedField("Stack-Trace", "```" + stackTrace + "```", false));
+
+
+        DiscordEmbed embed = new DiscordEmbed(
+                "🚨 Exception Occurred!",
+                null,
+                Color.RED.getRGB() & 0xFFFFFF,
+                fields
+        );
+
+        return new DiscordMessage("Unhandled Exception", List.of(embed));
+    }
+
+    private static String getClientIp(HttpServletRequest request) {
+        String[] headerCandidates = {
+                "X-Forwarded-For",
+                "Proxy-Client-IP",
+                "WL-Proxy-Client-IP",
+                "HTTP_X_FORWARDED_FOR",
+                "HTTP_X_FORWARDED",
+                "HTTP_X_CLUSTER_CLIENT_IP",
+                "HTTP_CLIENT_IP",
+                "HTTP_FORWARDED_FOR",
+                "HTTP_FORWARDED",
+                "HTTP_VIA",
+                "REMOTE_ADDR"
+        };
+
+        for (String header : headerCandidates) {
+            String ipList = request.getHeader(header);
+            if (ipList != null && ipList.length() != 0 && !"unknown".equalsIgnoreCase(ipList)) {
+                return ipList.split(",")[0];
+            }
+        }
+
+        return request.getRemoteAddr();
+    }
+} 

--- a/src/main/java/store/piku/back/global/notification/dto/DiscordEmbed.java
+++ b/src/main/java/store/piku/back/global/notification/dto/DiscordEmbed.java
@@ -1,0 +1,17 @@
+package store.piku.back.global.notification.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DiscordEmbed {
+    private String title;
+    private String description;
+    private int color;
+    private List<EmbedField> fields;
+} 

--- a/src/main/java/store/piku/back/global/notification/dto/DiscordMessage.java
+++ b/src/main/java/store/piku/back/global/notification/dto/DiscordMessage.java
@@ -1,0 +1,15 @@
+package store.piku.back.global.notification.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DiscordMessage {
+    private String content;
+    private List<DiscordEmbed> embeds;
+} 

--- a/src/main/java/store/piku/back/global/notification/dto/EmbedField.java
+++ b/src/main/java/store/piku/back/global/notification/dto/EmbedField.java
@@ -1,0 +1,14 @@
+package store.piku.back.global.notification.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class EmbedField {
+    private String name;
+    private String value;
+    private boolean inline;
+} 

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -10,3 +10,7 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
+
+discord:
+  webhook:
+    url: "discord_webhook_url"

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -13,4 +13,4 @@ spring:
 
 discord:
   webhook:
-    url: "discord_webhook_url"
+    url: "${DISCORD_WEBHOOK_URL:discord_webhook_url}"


### PR DESCRIPTION
## 📌 관련 이슈 (해당하는 경우)

<!-- 예시: closed: #123
     여러 개일 경우: closed: #123, closed: #124 -->
- closed: 

## ✨ 작업 내용 (이슈가 없을 경우 명시적으로 작성)

<!-- 아래 항목은 이슈가 없을 때 반드시 작성해주세요. -->
- 작업 요약: 서버에서 처리되지 않는 에러 발생 시 디스코드 웹훅으로 알림을 보냅니다
