### PR TITLE
AsyncRequestNotUsableExceptionHandler 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ uploads
 minio-data
 
 report
+
+.DS_Store

--- a/src/main/java/store/piku/back/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/store/piku/back/global/exception/GlobalExceptionHandler.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
+import org.springframework.web.context.request.async.AsyncRequestNotUsableException;
 import store.piku.back.global.dto.ValidationErrorResponse;
 import store.piku.back.global.error.ErrorCode;
 import store.piku.back.global.error.ErrorResponse;
@@ -163,6 +164,16 @@ public class GlobalExceptionHandler {
         log.error("유저를 찾을 수 없습니다: {}", e.getMessage());
         ErrorResponse response = new ErrorResponse(HttpStatus.NOT_FOUND.value(), e.getMessage());
         return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(AsyncRequestNotUsableException.class)
+    public void handleAsyncRequestNotUsableException(AsyncRequestNotUsableException e, HttpServletRequest request) {
+        log.error("비동기 요청을 사용할 수 없습니다. IP: {}, User-Agent: {}, API: {} {}, 원인: {}",
+                request.getRemoteAddr(),
+                request.getHeader("User-Agent"),
+                request.getMethod(),
+                request.getRequestURI(),
+                e.getMessage());
     }
 
     private boolean isConnectionReset(String message) {


### PR DESCRIPTION
## 📌 관련 이슈 (해당하는 경우)

<!-- 예시: closed: #123
     여러 개일 경우: closed: #123, closed: #124 -->
- closed: #148 

## ✨ 작업 내용 (이슈가 없을 경우 명시적으로 작성)

<!-- 아래 항목은 이슈가 없을 때 반드시 작성해주세요. -->
- 작업 요약:
`AsyncRequestNotUsableException`에 대한 글로벌 예외 처리 핸들러를 추가했습니다. 이 핸들러는 예외 발생 시 요청 IP, User-Agent, API URI 등의 정보를 포함한 에러 로그를 기록합니다