### PR TITLE
사용자 일기 사진 모아보기 API 추가

### DIFF
--- a/src/main/java/com/pikume/back/diary/adapter/in/web/DiaryController.java
+++ b/src/main/java/com/pikume/back/diary/adapter/in/web/DiaryController.java
@@ -5,6 +5,8 @@ import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.Validator;
@@ -21,14 +23,19 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import com.pikume.back.diary.adapter.in.web.dto.CalendarDiaryResponseDTO;
 import com.pikume.back.diary.adapter.in.web.dto.DiaryDTO;
+import com.pikume.back.diary.adapter.in.web.dto.DiaryGalleryItemResponse;
+import com.pikume.back.diary.adapter.in.web.dto.DiaryGalleryPageResponse;
 import com.pikume.back.diary.adapter.in.web.dto.ResponseDiaryDTO;
 import com.pikume.back.diary.application.dto.CalendarDiaryView;
 import com.pikume.back.diary.application.dto.CreateDiaryCommand;
 import com.pikume.back.diary.application.dto.DiaryCreatedResult;
+import com.pikume.back.diary.application.dto.DiaryGalleryItemView;
+import com.pikume.back.diary.application.dto.DiaryGalleryPage;
 import com.pikume.back.diary.application.dto.DiaryImageCommand;
 import com.pikume.back.diary.application.port.in.CreateDiaryUseCase;
 import com.pikume.back.diary.application.port.in.DeleteDiaryUseCase;
 import com.pikume.back.diary.application.port.in.GetCalendarUseCase;
+import com.pikume.back.diary.application.port.in.GetDiaryGalleryUseCase;
 import com.pikume.back.global.util.FileUtil;
 import com.pikume.back.global.config.CustomUserDetails;
 import com.pikume.back.global.dto.RequestMetaInfo;
@@ -52,6 +59,7 @@ public class DiaryController {
 	private final CreateDiaryUseCase createDiaryUseCase;
 	private final DeleteDiaryUseCase deleteDiaryUseCase;
 	private final GetCalendarUseCase getCalendarUseCase;
+	private final GetDiaryGalleryUseCase getDiaryGalleryUseCase;
 	private final FileUtil fileUtil;
 	private final RequestMetaMapper requestMetaMapper;
 	private final Validator validator;
@@ -168,8 +176,49 @@ public class DiaryController {
 				.body(diaries);
 	}
 
+	@Operation(summary = "사용자 일기 사진 갤러리 조회", description = "특정 사용자가 등록한 일기 대표 사진을 cursor 기반으로 조회합니다.")
+	@Parameters({
+			@Parameter(name = "userId", description = "사용자 ID", required = true),
+			@Parameter(name = "cursor", description = "다음 페이지 조회용 opaque cursor"),
+			@Parameter(name = "limit", description = "페이지 크기. 1~10 사이 정수이며 기본값은 10입니다.")
+	})
+	@GetMapping("/user/{userId}/gallery")
+	public ResponseEntity<DiaryGalleryPageResponse<DiaryGalleryItemResponse>> getUserDiaryGallery(
+			@PathVariable String userId,
+			@RequestParam(required = false) String cursor,
+			@RequestParam(defaultValue = "10") @Min(1) @Max(10) int limit,
+			@AuthenticationPrincipal CustomUserDetails userDetails) {
+		String viewerId = userDetails != null ? userDetails.getId() : null;
+		DiaryGalleryPage<DiaryGalleryItemView> page = getDiaryGalleryUseCase.findGallery(
+				userId,
+				viewerId,
+				cursor,
+				limit);
+
+		return ResponseEntity.ok(toDiaryGalleryPageResponse(page));
+	}
+
 	private CalendarDiaryResponseDTO toCalendarDiaryResponse(CalendarDiaryView diary) {
 		return new CalendarDiaryResponseDTO(diary.diaryId(), diary.coverPhotoUrl(), diary.date());
+	}
+
+	private DiaryGalleryPageResponse<DiaryGalleryItemResponse> toDiaryGalleryPageResponse(
+			DiaryGalleryPage<DiaryGalleryItemView> page) {
+		return new DiaryGalleryPageResponse<>(
+				page.items().stream()
+						.map(this::toDiaryGalleryItemResponse)
+						.toList(),
+				page.nextCursor(),
+				page.hasNext());
+	}
+
+	private DiaryGalleryItemResponse toDiaryGalleryItemResponse(DiaryGalleryItemView item) {
+		return new DiaryGalleryItemResponse(
+				item.diaryId(),
+				item.coverPhotoUrl(),
+				item.date().toString(),
+				item.imageCount(),
+				item.status());
 	}
 
 	private CreateDiaryCommand toCreateDiaryCommand(DiaryDTO diary) {

--- a/src/main/java/com/pikume/back/diary/adapter/in/web/DiaryExceptionHandler.java
+++ b/src/main/java/com/pikume/back/diary/adapter/in/web/DiaryExceptionHandler.java
@@ -10,7 +10,11 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import com.pikume.back.diary.adapter.in.web.problem.DiaryProblemType;
 import com.pikume.back.diary.application.exception.DiaryException;
+import com.pikume.back.diary.application.exception.InvalidDiaryGalleryCursorException;
 import com.pikume.back.global.error.ProblemDetailFactory;
+import com.pikume.back.global.error.ValidationProblemType;
+
+import java.util.Map;
 
 @RestControllerAdvice(basePackages = { "com.pikume.back.diary", "com.pikume.back.comment" })
 @RequiredArgsConstructor
@@ -27,6 +31,16 @@ public class DiaryExceptionHandler {
 	@ExceptionHandler(DiaryException.class)
 	public ResponseEntity<ProblemDetail> handleDiaryException(DiaryException ex, HttpServletRequest request) {
 		return problem(DiaryProblemType.from(ex.getErrorCode()), ex.getMessage(), request);
+	}
+
+	@ExceptionHandler(InvalidDiaryGalleryCursorException.class)
+	public ResponseEntity<ProblemDetail> handleInvalidDiaryGalleryCursorException(InvalidDiaryGalleryCursorException ex,
+			HttpServletRequest request) {
+		ProblemDetail problemDetail = problemDetailFactory.validation(
+				"요청 값이 올바르지 않습니다.",
+				request.getRequestURI(),
+				Map.of("cursor", ex.getMessage()));
+		return ResponseEntity.status(ValidationProblemType.INVALID_REQUEST.status()).body(problemDetail);
 	}
 
 	@ExceptionHandler(EntityNotFoundException.class)

--- a/src/main/java/com/pikume/back/diary/adapter/in/web/dto/DiaryGalleryItemResponse.java
+++ b/src/main/java/com/pikume/back/diary/adapter/in/web/dto/DiaryGalleryItemResponse.java
@@ -1,0 +1,12 @@
+package com.pikume.back.diary.adapter.in.web.dto;
+
+import com.pikume.back.diary.domain.vo.DiaryVisibility;
+
+public record DiaryGalleryItemResponse(
+		Long diaryId,
+		String coverPhotoUrl,
+		String date,
+		Long imageCount,
+		DiaryVisibility status
+) {
+}

--- a/src/main/java/com/pikume/back/diary/adapter/in/web/dto/DiaryGalleryPageResponse.java
+++ b/src/main/java/com/pikume/back/diary/adapter/in/web/dto/DiaryGalleryPageResponse.java
@@ -1,0 +1,10 @@
+package com.pikume.back.diary.adapter.in.web.dto;
+
+import java.util.List;
+
+public record DiaryGalleryPageResponse<T>(
+		List<T> items,
+		String nextCursor,
+		boolean hasNext
+) {
+}

--- a/src/main/java/com/pikume/back/diary/adapter/out/persistence/DiaryJpaRepository.java
+++ b/src/main/java/com/pikume/back/diary/adapter/out/persistence/DiaryJpaRepository.java
@@ -4,6 +4,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.query.Param;
+import com.pikume.back.diary.application.dto.DiaryGalleryRow;
 import com.pikume.back.diary.application.dto.DiaryMonthCountDTO;
 import com.pikume.back.diary.domain.Diary;
 import com.pikume.back.diary.domain.vo.DiaryVisibility;
@@ -37,6 +38,26 @@ public interface DiaryJpaRepository extends JpaRepository<Diary, Long> {
 			Collection<DiaryVisibility> statuses,
 			LocalDate start,
 			LocalDate end);
+
+	@Query("SELECT new com.pikume.back.diary.application.dto.DiaryGalleryRow(" +
+			"d.id, cover.url, d.date, COUNT(p.id), d.status) " +
+			"FROM Diary d " +
+			"JOIN Photo cover ON cover.diary = d AND cover.represent = true " +
+			"JOIN Photo p ON p.diary = d " +
+			"WHERE d.userId = :userId " +
+			"AND d.status IN :statuses " +
+			"AND d.deletedAt IS NULL " +
+			"AND (:cursorDate IS NULL " +
+			"OR d.date < :cursorDate " +
+			"OR (d.date = :cursorDate AND d.id < :cursorDiaryId)) " +
+			"GROUP BY d.id, cover.url, d.date, d.status " +
+			"ORDER BY d.date DESC, d.id DESC")
+	List<DiaryGalleryRow> findGalleryRowsByUserIdAndStatuses(
+			@Param("userId") String userId,
+			@Param("statuses") Collection<DiaryVisibility> statuses,
+			@Param("cursorDate") LocalDate cursorDate,
+			@Param("cursorDiaryId") Long cursorDiaryId,
+			Pageable pageable);
 
 	Optional<Diary> findByUserIdAndDateAndDeletedAtIsNull(String userId, LocalDate date);
 

--- a/src/main/java/com/pikume/back/diary/adapter/out/persistence/DiaryPersistenceAdapter.java
+++ b/src/main/java/com/pikume/back/diary/adapter/out/persistence/DiaryPersistenceAdapter.java
@@ -3,6 +3,7 @@ package com.pikume.back.diary.adapter.out.persistence;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import com.pikume.back.diary.application.dto.DiaryFeedCandidateView;
+import com.pikume.back.diary.application.dto.DiaryGalleryRow;
 import com.pikume.back.diary.application.dto.DiaryMonthCountDTO;
 import com.pikume.back.diary.application.port.out.LoadDiaryPort;
 import com.pikume.back.diary.application.port.out.SaveDiaryPort;
@@ -45,6 +46,23 @@ public class DiaryPersistenceAdapter implements LoadDiaryPort, SaveDiaryPort {
 	public List<Diary> findByUserIdAndStatusesAndDateBetween(String userId, Collection<DiaryVisibility> statuses, LocalDate start,
 			LocalDate end) {
 		return diaryJpaRepository.findByUserIdAndStatusInAndDeletedAtIsNullAndDateBetween(userId, statuses, start, end);
+	}
+
+	@Override
+	public List<DiaryGalleryRow> findGalleryRowsByUserIdAndStatuses(String userId,
+			Collection<DiaryVisibility> statuses,
+			LocalDate cursorDate,
+			Long cursorDiaryId,
+			int limit) {
+		if (statuses == null || statuses.isEmpty() || limit <= 0) {
+			return List.of();
+		}
+		return diaryJpaRepository.findGalleryRowsByUserIdAndStatuses(
+				userId,
+				statuses,
+				cursorDate,
+				cursorDiaryId,
+				org.springframework.data.domain.PageRequest.of(0, limit));
 	}
 
 	@Override

--- a/src/main/java/com/pikume/back/diary/application/dto/DiaryGalleryCursor.java
+++ b/src/main/java/com/pikume/back/diary/application/dto/DiaryGalleryCursor.java
@@ -1,0 +1,9 @@
+package com.pikume.back.diary.application.dto;
+
+import java.time.LocalDate;
+
+public record DiaryGalleryCursor(
+		LocalDate date,
+		Long diaryId
+) {
+}

--- a/src/main/java/com/pikume/back/diary/application/dto/DiaryGalleryItemView.java
+++ b/src/main/java/com/pikume/back/diary/application/dto/DiaryGalleryItemView.java
@@ -1,0 +1,14 @@
+package com.pikume.back.diary.application.dto;
+
+import com.pikume.back.diary.domain.vo.DiaryVisibility;
+
+import java.time.LocalDate;
+
+public record DiaryGalleryItemView(
+		Long diaryId,
+		String coverPhotoUrl,
+		LocalDate date,
+		Long imageCount,
+		DiaryVisibility status
+) {
+}

--- a/src/main/java/com/pikume/back/diary/application/dto/DiaryGalleryPage.java
+++ b/src/main/java/com/pikume/back/diary/application/dto/DiaryGalleryPage.java
@@ -1,0 +1,10 @@
+package com.pikume.back.diary.application.dto;
+
+import java.util.List;
+
+public record DiaryGalleryPage<T>(
+		List<T> items,
+		String nextCursor,
+		boolean hasNext
+) {
+}

--- a/src/main/java/com/pikume/back/diary/application/dto/DiaryGalleryRow.java
+++ b/src/main/java/com/pikume/back/diary/application/dto/DiaryGalleryRow.java
@@ -1,0 +1,14 @@
+package com.pikume.back.diary.application.dto;
+
+import com.pikume.back.diary.domain.vo.DiaryVisibility;
+
+import java.time.LocalDate;
+
+public record DiaryGalleryRow(
+		Long diaryId,
+		String coverPhotoPath,
+		LocalDate date,
+		Long imageCount,
+		DiaryVisibility status
+) {
+}

--- a/src/main/java/com/pikume/back/diary/application/exception/InvalidDiaryGalleryCursorException.java
+++ b/src/main/java/com/pikume/back/diary/application/exception/InvalidDiaryGalleryCursorException.java
@@ -1,0 +1,8 @@
+package com.pikume.back.diary.application.exception;
+
+public class InvalidDiaryGalleryCursorException extends RuntimeException {
+
+	public InvalidDiaryGalleryCursorException() {
+		super("유효하지 않은 갤러리 커서입니다.");
+	}
+}

--- a/src/main/java/com/pikume/back/diary/application/port/in/GetDiaryGalleryUseCase.java
+++ b/src/main/java/com/pikume/back/diary/application/port/in/GetDiaryGalleryUseCase.java
@@ -1,0 +1,9 @@
+package com.pikume.back.diary.application.port.in;
+
+import com.pikume.back.diary.application.dto.DiaryGalleryItemView;
+import com.pikume.back.diary.application.dto.DiaryGalleryPage;
+
+public interface GetDiaryGalleryUseCase {
+
+	DiaryGalleryPage<DiaryGalleryItemView> findGallery(String userId, String viewerId, String cursor, int limit);
+}

--- a/src/main/java/com/pikume/back/diary/application/port/out/LoadDiaryPort.java
+++ b/src/main/java/com/pikume/back/diary/application/port/out/LoadDiaryPort.java
@@ -2,6 +2,7 @@ package com.pikume.back.diary.application.port.out;
 
 import com.pikume.back.diary.application.dto.DiaryMonthCountDTO;
 import com.pikume.back.diary.application.dto.DiaryFeedCandidateView;
+import com.pikume.back.diary.application.dto.DiaryGalleryRow;
 import com.pikume.back.diary.domain.Diary;
 import com.pikume.back.diary.domain.Photo;
 import com.pikume.back.diary.domain.vo.DiaryVisibility;
@@ -24,6 +25,12 @@ public interface LoadDiaryPort {
 	List<Diary> findByUserIdAndDateBetween(String userId, LocalDate start, LocalDate end);
 
 	List<Diary> findByUserIdAndStatusesAndDateBetween(String userId, Collection<DiaryVisibility> statuses, LocalDate start, LocalDate end);
+
+	List<DiaryGalleryRow> findGalleryRowsByUserIdAndStatuses(String userId,
+			Collection<DiaryVisibility> statuses,
+			LocalDate cursorDate,
+			Long cursorDiaryId,
+			int limit);
 
 	Optional<Diary> findByUserIdAndDate(String userId, LocalDate date);
 

--- a/src/main/java/com/pikume/back/diary/application/service/DiaryGalleryCursorTokenCodec.java
+++ b/src/main/java/com/pikume/back/diary/application/service/DiaryGalleryCursorTokenCodec.java
@@ -1,0 +1,50 @@
+package com.pikume.back.diary.application.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import com.pikume.back.diary.application.dto.DiaryGalleryCursor;
+import com.pikume.back.diary.application.exception.InvalidDiaryGalleryCursorException;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+@Component
+@RequiredArgsConstructor
+public class DiaryGalleryCursorTokenCodec {
+
+	private final ObjectMapper objectMapper;
+
+	public String encode(DiaryGalleryCursor cursor) {
+		try {
+			String json = objectMapper.writeValueAsString(cursor);
+			return Base64.getUrlEncoder().withoutPadding()
+					.encodeToString(json.getBytes(StandardCharsets.UTF_8));
+		} catch (JsonProcessingException e) {
+			throw new InvalidDiaryGalleryCursorException();
+		}
+	}
+
+	public DiaryGalleryCursor decode(String token) {
+		if (token == null || token.isBlank()) {
+			return null;
+		}
+
+		try {
+			byte[] decoded = Base64.getUrlDecoder().decode(token);
+			DiaryGalleryCursor cursor = objectMapper.readValue(decoded, DiaryGalleryCursor.class);
+			validate(cursor);
+			return cursor;
+		} catch (IllegalArgumentException | IOException e) {
+			throw new InvalidDiaryGalleryCursorException();
+		}
+	}
+
+	private void validate(DiaryGalleryCursor cursor) {
+		if (cursor == null || cursor.date() == null || cursor.diaryId() == null || cursor.diaryId() <= 0) {
+			throw new InvalidDiaryGalleryCursorException();
+		}
+	}
+}

--- a/src/main/java/com/pikume/back/diary/application/service/DiaryQueryService.java
+++ b/src/main/java/com/pikume/back/diary/application/service/DiaryQueryService.java
@@ -6,6 +6,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import com.pikume.back.diary.application.dto.CalendarDiaryView;
 import com.pikume.back.diary.application.dto.DiaryFeedCandidateView;
+import com.pikume.back.diary.application.dto.DiaryGalleryCursor;
+import com.pikume.back.diary.application.dto.DiaryGalleryItemView;
+import com.pikume.back.diary.application.dto.DiaryGalleryPage;
+import com.pikume.back.diary.application.dto.DiaryGalleryRow;
 import com.pikume.back.diary.application.dto.DiaryPhotoView;
 import com.pikume.back.diary.application.policy.DiaryVisibilityPolicy;
 import com.pikume.back.diary.application.dto.DiarySummaryView;
@@ -15,6 +19,7 @@ import com.pikume.back.diary.application.dto.VisibleDiaryDetailView;
 import com.pikume.back.diary.application.exception.DiaryNotFoundException;
 import com.pikume.back.diary.application.port.in.QueryDiaryFeedUseCase;
 import com.pikume.back.diary.application.port.in.GetCalendarUseCase;
+import com.pikume.back.diary.application.port.in.GetDiaryGalleryUseCase;
 import com.pikume.back.diary.application.port.in.QueryDiaryReadUseCase;
 import com.pikume.back.diary.application.port.in.QueryDiaryVisibilityUseCase;
 import com.pikume.back.diary.application.port.out.LoadDiaryPort;
@@ -36,11 +41,12 @@ import java.util.stream.Collectors;
 @Slf4j
 @RequiredArgsConstructor
 public class DiaryQueryService implements GetCalendarUseCase, QueryDiaryVisibilityUseCase, QueryDiaryReadUseCase,
-		QueryDiaryFeedUseCase {
+		QueryDiaryFeedUseCase, GetDiaryGalleryUseCase {
 
 	private final LoadDiaryPort loadDiaryPort;
 	private final PhotoStoragePort photoStoragePort;
 	private final DiaryVisibilityPolicy diaryVisibilityPolicy;
+	private final DiaryGalleryCursorTokenCodec diaryGalleryCursorTokenCodec;
 
 	@Override
 	public Optional<VisibleDiaryView> findVisibleDiaryById(Long diaryId, String viewerId) {
@@ -88,12 +94,39 @@ public class DiaryQueryService implements GetCalendarUseCase, QueryDiaryVisibili
 
 		return diaries.stream()
 				.map(diary -> {
-			String coverPhotoUrl = loadDiaryPort.findRepresentPhotoByDiaryId(diary.getId())
-					.map(Photo::getUrl)
-					.map(url -> photoStoragePort.getPhotoUrl(url, true))
-					.orElse(null);
-			return new CalendarDiaryView(diary.getId(), coverPhotoUrl, diary.getDate());
-		}).collect(Collectors.toList());
+					String coverPhotoUrl = loadDiaryPort.findRepresentPhotoByDiaryId(diary.getId())
+							.map(Photo::getUrl)
+							.map(url -> photoStoragePort.getPhotoUrl(url, true))
+							.orElse(null);
+					return new CalendarDiaryView(diary.getId(), coverPhotoUrl, diary.getDate());
+				}).collect(Collectors.toList());
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public DiaryGalleryPage<DiaryGalleryItemView> findGallery(String userId, String viewerId, String cursorToken, int limit) {
+		DiaryGalleryCursor cursor = diaryGalleryCursorTokenCodec.decode(cursorToken);
+		Set<com.pikume.back.diary.domain.vo.DiaryVisibility> visibleStatuses = Set.copyOf(
+				diaryVisibilityPolicy.visibleStatusesForOwner(userId, viewerId));
+
+		int fetchLimit = limit + 1;
+		List<DiaryGalleryRow> rows = loadDiaryPort.findGalleryRowsByUserIdAndStatuses(
+				userId,
+				visibleStatuses,
+				cursor != null ? cursor.date() : null,
+				cursor != null ? cursor.diaryId() : null,
+				fetchLimit);
+
+		boolean hasNext = rows.size() > limit;
+		List<DiaryGalleryRow> pageRows = hasNext ? rows.subList(0, limit) : rows;
+		List<DiaryGalleryItemView> items = pageRows.stream()
+				.map(this::toDiaryGalleryItemView)
+				.toList();
+		String nextCursor = hasNext && !pageRows.isEmpty()
+				? diaryGalleryCursorTokenCodec.encode(toGalleryCursor(pageRows.get(pageRows.size() - 1)))
+				: null;
+
+		return new DiaryGalleryPage<>(items, nextCursor, hasNext);
 	}
 
 	@Override
@@ -227,5 +260,18 @@ public class DiaryQueryService implements GetCalendarUseCase, QueryDiaryVisibili
 				diary.getContent(),
 				diary.getDate(),
 				diary.getCreatedAt());
+	}
+
+	private DiaryGalleryItemView toDiaryGalleryItemView(DiaryGalleryRow row) {
+		return new DiaryGalleryItemView(
+				row.diaryId(),
+				photoStoragePort.getPhotoUrl(row.coverPhotoPath(), true),
+				row.date(),
+				row.imageCount(),
+				row.status());
+	}
+
+	private DiaryGalleryCursor toGalleryCursor(DiaryGalleryRow row) {
+		return new DiaryGalleryCursor(row.date(), row.diaryId());
 	}
 }

--- a/src/test/java/com/pikume/back/diary/adapter/in/web/DiaryControllerTest.java
+++ b/src/test/java/com/pikume/back/diary/adapter/in/web/DiaryControllerTest.java
@@ -7,11 +7,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.ProblemDetail;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.core.MethodParameter;
 import org.springframework.web.bind.support.WebDataBinderFactory;
@@ -20,6 +22,11 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 import com.pikume.back.diary.application.port.in.CreateDiaryUseCase;
 import com.pikume.back.diary.application.port.in.DeleteDiaryUseCase;
 import com.pikume.back.diary.application.port.in.GetCalendarUseCase;
+import com.pikume.back.diary.application.dto.DiaryGalleryItemView;
+import com.pikume.back.diary.application.dto.DiaryGalleryPage;
+import com.pikume.back.diary.application.exception.InvalidDiaryGalleryCursorException;
+import com.pikume.back.diary.application.port.in.GetDiaryGalleryUseCase;
+import com.pikume.back.diary.domain.vo.DiaryVisibility;
 import com.pikume.back.global.config.CustomUserDetails;
 import com.pikume.back.global.error.ProblemDetailFactory;
 import com.pikume.back.global.exception.GlobalExceptionHandler;
@@ -28,8 +35,14 @@ import com.pikume.back.global.util.RequestMetaMapper;
 
 import java.util.Optional;
 
+import java.time.LocalDate;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -48,6 +61,9 @@ class DiaryControllerTest {
 	private GetCalendarUseCase getCalendarUseCase;
 
 	@Mock
+	private GetDiaryGalleryUseCase getDiaryGalleryUseCase;
+
+	@Mock
 	private FileUtil fileUtil;
 
 	@Mock
@@ -61,16 +77,23 @@ class DiaryControllerTest {
 
 	@BeforeEach
 	void setUp() {
+		ProblemDetailFactory problemDetailFactory = new ProblemDetailFactory();
+		LocalValidatorFactoryBean mvcValidator = new LocalValidatorFactoryBean();
+		mvcValidator.afterPropertiesSet();
 		diaryController = new DiaryController(
 				createDiaryUseCase,
 				deleteDiaryUseCase,
 				getCalendarUseCase,
+				getDiaryGalleryUseCase,
 				fileUtil,
 				requestMetaMapper,
 				validator,
-				new ProblemDetailFactory());
+				problemDetailFactory);
 		mockMvc = MockMvcBuilders.standaloneSetup(diaryController)
-				.setControllerAdvice(new GlobalExceptionHandler(Optional.empty(), new ProblemDetailFactory()))
+				.setControllerAdvice(
+						new GlobalExceptionHandler(Optional.empty(), problemDetailFactory),
+						new DiaryExceptionHandler(problemDetailFactory))
+				.setValidator(mvcValidator)
 				.setCustomArgumentResolvers(new AuthenticationPrincipalResolver())
 				.build();
 	}
@@ -106,6 +129,66 @@ class DiaryControllerTest {
 				.andExpect(jsonPath("$.status").value(400))
 				.andExpect(jsonPath("$.detail").value("요청 본문을 해석할 수 없습니다."))
 				.andExpect(jsonPath("$.instance").value("/api/diary"));
+	}
+
+	@Test
+	@DisplayName("GET /api/diary/user/{userId}/gallery는 사용자 사진 갤러리 page shape를 반환한다")
+	void getUserDiaryGalleryReturnsCursorPage() throws Exception {
+		DiaryGalleryPage<DiaryGalleryItemView> page = new DiaryGalleryPage<>(
+				List.of(new DiaryGalleryItemView(
+						10L,
+						"https://cdn.example/cover.jpg",
+						LocalDate.of(2026, 5, 31),
+						3L,
+						DiaryVisibility.FRIENDS)),
+				"opaque-next-cursor",
+				true);
+		given(getDiaryGalleryUseCase.findGallery("profile-1", "user1", null, 10))
+				.willReturn(page);
+
+		mockMvc.perform(get("/api/diary/user/profile-1/gallery")
+						.accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.items[0].diaryId").value(10L))
+				.andExpect(jsonPath("$.items[0].coverPhotoUrl").value("https://cdn.example/cover.jpg"))
+				.andExpect(jsonPath("$.items[0].date").value("2026-05-31"))
+				.andExpect(jsonPath("$.items[0].imageCount").value(3L))
+				.andExpect(jsonPath("$.items[0].status").value("FRIENDS"))
+				.andExpect(jsonPath("$.nextCursor").value("opaque-next-cursor"))
+				.andExpect(jsonPath("$.hasNext").value(true));
+
+		then(getDiaryGalleryUseCase).should()
+				.findGallery("profile-1", "user1", null, 10);
+	}
+
+	@Test
+	@DisplayName("GET /api/diary/user/{userId}/gallery는 limit 10 초과를 validation Problem Details로 거부한다")
+	void getUserDiaryGalleryRejectsTooLargeLimit() throws Exception {
+		mockMvc.perform(get("/api/diary/user/profile-1/gallery")
+						.param("limit", "11")
+						.accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.type").value("https://api.pikume.com/problems/validation/invalid-request"))
+				.andExpect(jsonPath("$.status").value(400))
+				.andExpect(jsonPath("$.fieldErrors.limit").exists());
+
+		then(getDiaryGalleryUseCase).shouldHaveNoInteractions();
+	}
+
+	@Test
+	@DisplayName("GET /api/diary/user/{userId}/gallery는 잘못된 cursor를 validation Problem Details로 반환한다")
+	void getUserDiaryGalleryRejectsInvalidCursorWithProblemDetails() throws Exception {
+		given(getDiaryGalleryUseCase.findGallery("profile-1", "user1", "bad", 10))
+				.willThrow(new InvalidDiaryGalleryCursorException());
+
+		mockMvc.perform(get("/api/diary/user/profile-1/gallery")
+						.param("cursor", "bad")
+						.accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.type").value("https://api.pikume.com/problems/validation/invalid-request"))
+				.andExpect(jsonPath("$.status").value(400))
+				.andExpect(jsonPath("$.fieldErrors.cursor").value("유효하지 않은 갤러리 커서입니다."))
+				.andExpect(jsonPath("$.instance").value("/api/diary/user/profile-1/gallery"));
 	}
 
 	private static class AuthenticationPrincipalResolver implements HandlerMethodArgumentResolver {

--- a/src/test/java/com/pikume/back/diary/adapter/out/persistence/DiaryJpaRepositoryGalleryTest.java
+++ b/src/test/java/com/pikume/back/diary/adapter/out/persistence/DiaryJpaRepositoryGalleryTest.java
@@ -1,0 +1,101 @@
+package com.pikume.back.diary.adapter.out.persistence;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.data.domain.PageRequest;
+import com.pikume.back.diary.application.dto.DiaryGalleryRow;
+import com.pikume.back.diary.domain.Diary;
+import com.pikume.back.diary.domain.Photo;
+import com.pikume.back.diary.domain.vo.DiaryVisibility;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@DisplayName("DiaryJpaRepository gallery query")
+class DiaryJpaRepositoryGalleryTest {
+
+	@Autowired
+	private DiaryJpaRepository diaryJpaRepository;
+
+	@Autowired
+	private PhotoJpaRepository photoJpaRepository;
+
+	@Autowired
+	private TestEntityManager entityManager;
+
+	@Test
+	@DisplayName("갤러리 row는 사진 없는 일기와 허용되지 않은 공개범위를 제외하고 date DESC, id DESC로 반환한다")
+	void galleryRowsExcludePhotoLessAndHiddenStatuses() {
+		String userId = "user-1";
+		saveDiary(userId, "photo-less", DiaryVisibility.PUBLIC, LocalDate.of(2026, 5, 31));
+		Diary privateDiary = saveDiary(userId, "private", DiaryVisibility.PRIVATE, LocalDate.of(2026, 5, 31));
+		Diary latestDifferentMonth = saveDiary(userId, "latest", DiaryVisibility.PUBLIC, LocalDate.of(2026, 6, 1));
+		Diary olderSameDate = saveDiary(userId, "older", DiaryVisibility.PUBLIC, LocalDate.of(2026, 5, 30));
+		Diary newerSameDate = saveDiary(userId, "newer", DiaryVisibility.PUBLIC, LocalDate.of(2026, 5, 30));
+		saveRepresentPhoto(privateDiary, "public/user-1/private.jpg");
+		saveRepresentPhoto(latestDifferentMonth, "public/user-1/latest-cover.jpg");
+		saveRepresentPhoto(olderSameDate, "public/user-1/older-cover.jpg");
+		savePhoto(olderSameDate, "user-1/older-second.jpg", 1);
+		saveRepresentPhoto(newerSameDate, "public/user-1/newer-cover.jpg");
+		flushAndClear();
+
+		List<DiaryGalleryRow> rows = diaryJpaRepository.findGalleryRowsByUserIdAndStatuses(
+				userId,
+				Set.of(DiaryVisibility.PUBLIC),
+				null,
+				null,
+				PageRequest.of(0, 10));
+
+		assertThat(rows).extracting(DiaryGalleryRow::diaryId)
+				.containsExactly(latestDifferentMonth.getId(), newerSameDate.getId(), olderSameDate.getId());
+		assertThat(rows.get(0).coverPhotoPath()).isEqualTo("public/user-1/latest-cover.jpg");
+		assertThat(rows.get(2).imageCount()).isEqualTo(2L);
+	}
+
+	@Test
+	@DisplayName("갤러리 cursor는 같은 날짜에서는 더 작은 diaryId부터 이어진다")
+	void galleryRowsApplyDateAndDiaryIdCursor() {
+		String userId = "user-1";
+		Diary olderSameDate = saveDiary(userId, "older", DiaryVisibility.PUBLIC, LocalDate.of(2026, 5, 30));
+		Diary newerSameDate = saveDiary(userId, "newer", DiaryVisibility.PUBLIC, LocalDate.of(2026, 5, 30));
+		saveRepresentPhoto(olderSameDate, "public/user-1/older-cover.jpg");
+		saveRepresentPhoto(newerSameDate, "public/user-1/newer-cover.jpg");
+		flushAndClear();
+
+		List<DiaryGalleryRow> rows = diaryJpaRepository.findGalleryRowsByUserIdAndStatuses(
+				userId,
+				Set.of(DiaryVisibility.PUBLIC),
+				LocalDate.of(2026, 5, 30),
+				newerSameDate.getId(),
+				PageRequest.of(0, 10));
+
+		assertThat(rows).extracting(DiaryGalleryRow::diaryId)
+				.containsExactly(olderSameDate.getId());
+	}
+
+	private Diary saveDiary(String userId, String content, DiaryVisibility visibility, LocalDate date) {
+		return diaryJpaRepository.save(new Diary(content, visibility, date, userId));
+	}
+
+	private void saveRepresentPhoto(Diary diary, String path) {
+		Photo photo = new Photo(diary, path, 0);
+		photo.updateRepresent(true);
+		photoJpaRepository.save(photo);
+	}
+
+	private void savePhoto(Diary diary, String path, int order) {
+		photoJpaRepository.save(new Photo(diary, path, order));
+	}
+
+	private void flushAndClear() {
+		entityManager.flush();
+		entityManager.clear();
+	}
+}

--- a/src/test/java/com/pikume/back/diary/application/service/DiaryGalleryCursorTokenCodecTest.java
+++ b/src/test/java/com/pikume/back/diary/application/service/DiaryGalleryCursorTokenCodecTest.java
@@ -1,0 +1,54 @@
+package com.pikume.back.diary.application.service;
+
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import com.pikume.back.diary.application.dto.DiaryGalleryCursor;
+import com.pikume.back.diary.application.exception.InvalidDiaryGalleryCursorException;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("DiaryGalleryCursorTokenCodec")
+class DiaryGalleryCursorTokenCodecTest {
+
+	private final DiaryGalleryCursorTokenCodec codec = new DiaryGalleryCursorTokenCodec(
+			JsonMapper.builder().findAndAddModules().build());
+
+	@Test
+	@DisplayName("갤러리 cursor를 opaque token으로 인코딩하고 다시 디코딩한다")
+	void encodesAndDecodesCursor() {
+		DiaryGalleryCursor cursor = new DiaryGalleryCursor(LocalDate.of(2026, 5, 31), 42L);
+
+		String token = codec.encode(cursor);
+		DiaryGalleryCursor decoded = codec.decode(token);
+
+		assertThat(token).isNotBlank();
+		assertThat(decoded).isEqualTo(cursor);
+	}
+
+	@Test
+	@DisplayName("빈 cursor token은 첫 페이지로 해석한다")
+	void decodesBlankCursorAsFirstPage() {
+		assertThat(codec.decode(null)).isNull();
+		assertThat(codec.decode(" ")).isNull();
+	}
+
+	@Test
+	@DisplayName("형식이 잘못된 cursor token은 갤러리 cursor 예외를 던진다")
+	void rejectsMalformedCursor() {
+		assertThatThrownBy(() -> codec.decode("not-base64"))
+				.isInstanceOf(InvalidDiaryGalleryCursorException.class);
+	}
+
+	@Test
+	@DisplayName("정렬 키가 부족한 cursor token은 갤러리 cursor 예외를 던진다")
+	void rejectsCursorMissingSortKey() {
+		String token = codec.encode(new DiaryGalleryCursor(LocalDate.of(2026, 5, 31), 0L));
+
+		assertThatThrownBy(() -> codec.decode(token))
+				.isInstanceOf(InvalidDiaryGalleryCursorException.class);
+	}
+}

--- a/src/test/java/com/pikume/back/diary/application/service/DiaryQueryServiceTest.java
+++ b/src/test/java/com/pikume/back/diary/application/service/DiaryQueryServiceTest.java
@@ -9,8 +9,13 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import com.pikume.back.diary.application.dto.CalendarDiaryView;
+import com.pikume.back.diary.application.dto.DiaryGalleryCursor;
+import com.pikume.back.diary.application.dto.DiaryGalleryItemView;
+import com.pikume.back.diary.application.dto.DiaryGalleryPage;
+import com.pikume.back.diary.application.dto.DiaryGalleryRow;
 import com.pikume.back.diary.application.dto.DiaryMonthCountDTO;
 import com.pikume.back.diary.application.dto.VisibleDiaryView;
+import com.pikume.back.diary.application.exception.InvalidDiaryGalleryCursorException;
 import com.pikume.back.diary.application.policy.DiaryVisibilityPolicy;
 import com.pikume.back.diary.application.port.out.LoadDiaryPort;
 import com.pikume.back.diary.application.port.out.PhotoStoragePort;
@@ -42,6 +47,8 @@ class DiaryQueryServiceTest {
 	private PhotoStoragePort photoStoragePort;
 	@Mock
 	private DiaryVisibilityPolicy diaryVisibilityPolicy;
+	@Mock
+	private DiaryGalleryCursorTokenCodec diaryGalleryCursorTokenCodec;
 
 	private static final String USER_ID = "user-1";
 
@@ -216,6 +223,110 @@ class DiaryQueryServiceTest {
 
 			then(diaryVisibilityPolicy).should().visibleStatusesForOwner(USER_ID, "viewer-id");
 			then(diaryVisibilityPolicy).should(never()).isHiddenFromViewer(any(Diary.class), eq("viewer-id"));
+		}
+	}
+
+	@Nested
+	@DisplayName("findGallery")
+	class FindGallery {
+
+		@Test
+		@DisplayName("사용자 사진 갤러리는 limit+1로 조회하고 다음 cursor를 마지막 반환 item 기준으로 만든다")
+		void returnsGalleryPageWithNextCursor() {
+			DiaryGalleryRow first = new DiaryGalleryRow(
+					31L,
+					"public/user-1/31.jpg",
+					LocalDate.of(2026, 6, 1),
+					2L,
+					DiaryVisibility.PUBLIC);
+			DiaryGalleryRow second = new DiaryGalleryRow(
+					20L,
+					"public/user-1/20.jpg",
+					LocalDate.of(2026, 5, 30),
+					1L,
+					DiaryVisibility.FRIENDS);
+			DiaryGalleryRow extra = new DiaryGalleryRow(
+					10L,
+					"public/user-1/10.jpg",
+					LocalDate.of(2026, 5, 29),
+					1L,
+					DiaryVisibility.PUBLIC);
+
+			given(diaryVisibilityPolicy.visibleStatusesForOwner(USER_ID, "viewer-id"))
+					.willReturn(List.of(DiaryVisibility.PUBLIC, DiaryVisibility.FRIENDS));
+			given(loadDiaryPort.findGalleryRowsByUserIdAndStatuses(
+					eq(USER_ID),
+					eq(Set.of(DiaryVisibility.PUBLIC, DiaryVisibility.FRIENDS)),
+					isNull(),
+					isNull(),
+					eq(3)))
+					.willReturn(List.of(first, second, extra));
+			given(photoStoragePort.getPhotoUrl("public/user-1/31.jpg", true))
+					.willReturn("https://cdn.example/31.jpg");
+			given(photoStoragePort.getPhotoUrl("public/user-1/20.jpg", true))
+					.willReturn("https://cdn.example/20.jpg");
+			given(diaryGalleryCursorTokenCodec.encode(new DiaryGalleryCursor(LocalDate.of(2026, 5, 30), 20L)))
+					.willReturn("opaque-next-cursor");
+
+			DiaryGalleryPage<DiaryGalleryItemView> result = diaryQueryService.findGallery(
+					USER_ID,
+					"viewer-id",
+					null,
+					2);
+
+			assertThat(result.items()).hasSize(2);
+			assertThat(result.items()).extracting(DiaryGalleryItemView::diaryId)
+					.containsExactly(31L, 20L);
+			assertThat(result.items().get(0).coverPhotoUrl()).isEqualTo("https://cdn.example/31.jpg");
+			assertThat(result.items().get(0).imageCount()).isEqualTo(2L);
+			assertThat(result.items().get(0).status()).isEqualTo(DiaryVisibility.PUBLIC);
+			assertThat(result.items().get(1).date()).isEqualTo(LocalDate.of(2026, 5, 30));
+			assertThat(result.nextCursor()).isEqualTo("opaque-next-cursor");
+			assertThat(result.hasNext()).isTrue();
+			then(photoStoragePort).should(never()).getPhotoUrl("public/user-1/10.jpg", true);
+		}
+
+		@Test
+		@DisplayName("cursor가 있으면 디코딩한 date/diaryId 이후의 사진 row만 요청한다")
+		void passesDecodedCursorToGalleryQuery() {
+			DiaryGalleryCursor cursor = new DiaryGalleryCursor(LocalDate.of(2026, 5, 30), 20L);
+			given(diaryGalleryCursorTokenCodec.decode("opaque-cursor")).willReturn(cursor);
+			given(diaryVisibilityPolicy.visibleStatusesForOwner(USER_ID, null))
+					.willReturn(List.of(DiaryVisibility.PUBLIC));
+			given(loadDiaryPort.findGalleryRowsByUserIdAndStatuses(
+					eq(USER_ID),
+					eq(Set.of(DiaryVisibility.PUBLIC)),
+					eq(LocalDate.of(2026, 5, 30)),
+					eq(20L),
+					eq(31)))
+					.willReturn(List.of());
+
+			DiaryGalleryPage<DiaryGalleryItemView> result = diaryQueryService.findGallery(
+					USER_ID,
+					null,
+					"opaque-cursor",
+					30);
+
+			assertThat(result.items()).isEmpty();
+			assertThat(result.nextCursor()).isNull();
+			assertThat(result.hasNext()).isFalse();
+			then(photoStoragePort).shouldHaveNoInteractions();
+		}
+
+		@Test
+		@DisplayName("잘못된 cursor는 저장소 조회 전에 갤러리 cursor 예외로 거부한다")
+		void rejectsInvalidCursorBeforeLoadingRows() {
+			given(diaryGalleryCursorTokenCodec.decode("bad-cursor"))
+					.willThrow(new InvalidDiaryGalleryCursorException());
+
+			assertThatThrownBy(() -> diaryQueryService.findGallery(
+					USER_ID,
+					"viewer-id",
+					"bad-cursor",
+					30))
+					.isInstanceOf(InvalidDiaryGalleryCursorException.class);
+
+			then(loadDiaryPort).shouldHaveNoInteractions();
 		}
 	}
 


### PR DESCRIPTION
## ✨ 작업 내용 (이슈가 없을 경우 명시적으로 작성)
사용자가 올린 일기의 사진들을 호출할 수 있는 API를 추가합니다
API는 다음 제약조건을 따릅니다
1. 커서기반 페이지네이션이 적용됩니다.
2. 요청 시 사진 경로는 최대 10개까지만 가능합니다.