### PR TITLE
이미지 저장 정책 변경

### DIFF
--- a/.codex/skills/write-design-doc/SKILL.md
+++ b/.codex/skills/write-design-doc/SKILL.md
@@ -19,6 +19,7 @@ Use this skill for `piku-back` design documentation work only.
 - Place official documents under the appropriate `docs/` category and update the matching index when creating a new official document.
 - Include a required `Commit Message` section in every completed design document.
 - Write the commit message in Korean and follow `docs/standards/engineering-workflow.md`: `<type>: <description>`, no scope, no file-name list, no internal phase labels.
+- Base the `Commit Message` on the intended product or engineering work described by the document, not on the act of creating or editing the document. Use `docs:` only when the actual work is documentation-only maintenance.
 
 ## Document Shape
 
@@ -51,4 +52,4 @@ Before presenting or saving the design document, verify:
 - The document explains feature and architecture flow clearly enough for implementation planning.
 - DDD + hexagonal architecture boundaries are explicit where relevant.
 - A Korean `Commit Message` section is present.
-- The design document is placed under `docs/superpowers/plan`.
+- The design document is placed under `docs/superpowers/plans`.

--- a/docs/indexes/runbooks-index.md
+++ b/docs/indexes/runbooks-index.md
@@ -3,7 +3,7 @@
 - Status: Active
 - Audience: Engineers
 - Source of Truth: Yes
-- Last Reviewed: 2026-05-28
+- Last Reviewed: 2026-06-12
 
 ## 목적
 
@@ -12,4 +12,5 @@
 ## Active Documents
 
 - [Documentation Maintenance Runbook](../runbooks/documentation-maintenance-runbook.md): 문서 추가/수정/삭제/검증 절차
+- [Diary Image Storage Runbook](../runbooks/diary-image-storage-runbook.md): 일기 이미지 저장 경로, 공개범위 변경, legacy 호환, 캐시 정책 운영 현황
 - [Photo WebP Optimization Runbook](../runbooks/photo-webp-optimization-runbook.md): 일기 사진 WebP 최적화 스케줄러 설정, 상태 전이, 운영 확인 절차

--- a/docs/runbooks/diary-image-storage-runbook.md
+++ b/docs/runbooks/diary-image-storage-runbook.md
@@ -1,0 +1,165 @@
+# Diary Image Storage Runbook
+
+- Status: Active
+- Audience: Engineers, Operators
+- Source of Truth: Yes
+- Last Reviewed: 2026-06-12
+
+## 목적
+
+일기 이미지의 저장 경로, 공개범위 변경 방식, legacy 호환, 조회 URL 발급, 캐시 정책을 운영자가 빠르게 확인하기 위한 문서다.
+
+## 요약
+
+bucket 이름은 DB object key에 포함하지 않는다. `photos.url`, `photos.optimizedUrl`, `diary_image_generation.filePath`에는 bucket 내부 object key만 저장한다.
+
+private object의 URL은 공개 URL이 아니다. Diary 공개범위, 소유자, 친구 관계 검증이 끝난 조회 흐름에서만 임시 URL을 발급한다. URL 변환은 인가 수단이 아니다.
+
+legacy object key에는 사용자 식별자가 포함될 수 있다. 로그, 이슈, 외부 공유 문서에서는 개인정보성 경로 데이터로 취급한다.
+
+## 현재 경로
+
+| 대상 | 현재 경로 |
+| --- | --- |
+| 공개 또는 익명 일기의 사용자 업로드 사진 | `public/diary-images/user/{prefix1}/{prefix2}/{uuid}.{ext}` |
+| 비공개 또는 친구 공개 일기의 사용자 업로드 사진 | `private/diary-images/user/{prefix1}/{prefix2}/{uuid}.{ext}` |
+| 일기에 아직 연결되지 않은 신규 AI 임시 이미지 | `private/diary-images/ai/{prefix1}/{prefix2}/{uuid}.{ext}` |
+| WebP 최적화 이미지 | 원본 object key와 같은 scope, 같은 base path, WebP 확장자 |
+| legacy 사용자 업로드 사진 | 기존 key 유지. 공개범위 변경 시 canonical 경로로 옮겨질 수 있음 |
+| legacy AI 이미지 | 기존 key 유지. 공개 일기 연결 시 기존 구조 그대로 public scope로 이동할 수 있음 |
+
+## 변경 방식
+
+| 상황 | 변경 방식 |
+| --- | --- |
+| 신규 사용자 업로드 사진 저장 | 일기 공개범위 기준으로 public 또는 private scope를 결정한다. 대표 사진 여부는 저장 scope 기준이 아니다. |
+| 신규 AI 이미지 생성 | 연결될 일기 공개범위가 아직 없으므로 private scope에 임시 저장한다. |
+| 신규 AI 이미지를 공개 또는 익명 일기에 연결 | private AI object를 public AI object로 복사하고, 복사 검증 후 private 임시 object를 삭제한다. |
+| 신규 AI 이미지를 비공개 또는 친구 공개 일기에 연결 | 기존 private AI object를 유지한다. |
+| canonical 일기 사진의 공개범위 변경 | `public/diary-images/{source}/...` 와 `private/diary-images/{source}/...` 사이에서 scope prefix를 바꾼 object로 복사한다. |
+| legacy 사용자 업로드 사진의 공개범위 변경 | target scope의 canonical 일기 이미지 key로 새로 복사할 수 있다. 이때 legacy 경로의 사용자 식별자는 새 경로에서 제거된다. |
+| DB 갱신 전 실패 | 새로 복사된 object를 rollback cleanup 대상으로 삭제한다. |
+| DB 갱신 후 이전 object 삭제 실패 | 사용자-facing 결과는 유지하고, 실패 로그를 후속 정리 대상으로 본다. |
+
+## 저장 흐름
+
+```mermaid
+sequenceDiagram
+    participant Client as Client
+    participant Diary as Diary UseCase
+    participant PhotoStorage as PhotoStoragePort
+    participant Storage as S3 or MinIO
+    participant DB as Diary DB
+
+    Client->>Diary: 일기 생성 요청
+    Diary->>DB: Diary 저장
+    Diary->>PhotoStorage: 사용자 업로드 사진 저장 요청
+    PhotoStorage->>Storage: 공개범위 기준 object 저장
+    PhotoStorage->>DB: Photo object key 저장
+    Diary-->>Client: 생성 결과 반환
+```
+
+## AI 이미지 연결 흐름
+
+```mermaid
+sequenceDiagram
+    participant Client as Client
+    participant Creative as Creative UseCase
+    participant Diary as Diary UseCase
+    participant PhotoStorage as PhotoStoragePort
+    participant Storage as S3 or MinIO
+    participant DB as Diary and Creative DB
+
+    Client->>Creative: AI 이미지 생성 요청
+    Creative->>PhotoStorage: private 임시 object 저장
+    PhotoStorage->>Storage: private AI object 저장
+    Creative->>DB: 생성 이력 저장
+    Creative-->>Client: AI 이미지 ID와 미리보기 URL 반환
+
+    Client->>Diary: AI 이미지 포함 일기 생성 요청
+    Diary->>DB: 생성 이력 조회
+    alt 공개 또는 익명 일기
+        Diary->>PhotoStorage: public scope 이동 요청
+        PhotoStorage->>Storage: private object를 public object로 복사
+        PhotoStorage->>Storage: 복사 검증 후 private object 삭제
+        Diary->>DB: Photo key와 생성 이력 filePath 갱신
+    else 비공개 또는 친구 공개 일기
+        Diary->>DB: 기존 private key로 Photo 저장
+    end
+```
+
+## 공개범위 변경 흐름
+
+```mermaid
+sequenceDiagram
+    participant Client as Client
+    participant Diary as Diary UseCase
+    participant PhotoStorage as PhotoStoragePort
+    participant Storage as S3 or MinIO
+    participant DB as Diary DB
+
+    Client->>Diary: 일기 공개범위 변경 요청
+    Diary->>DB: 연결된 Photo 조회
+    Diary->>PhotoStorage: 원본과 WebP object를 target scope로 복사
+    PhotoStorage->>Storage: target object 복사
+    PhotoStorage->>Storage: target object 검증
+    Diary->>DB: Photo key와 Diary 공개범위 갱신
+    alt commit 성공
+        Diary->>PhotoStorage: 이전 object 삭제
+        PhotoStorage->>Storage: old object 삭제
+    else 실패 또는 rollback
+        Diary->>PhotoStorage: 새로 복사된 object 삭제
+        PhotoStorage->>Storage: copied object cleanup
+    end
+```
+
+## 조회 흐름
+
+```mermaid
+sequenceDiagram
+    participant Client as Client
+    participant Query as Query UseCase
+    participant Policy as Visibility Policy
+    participant UrlResolver as ResolveImageUrlPort
+    participant Storage as S3 or MinIO
+    participant DB as Diary DB
+
+    Client->>Query: 일기 또는 피드 조회
+    Query->>DB: Diary와 Photo object key 조회
+    Query->>Policy: 조회 권한 확인
+    Policy-->>Query: 접근 허용
+    Query->>UrlResolver: object key를 접근 URL로 변환
+    UrlResolver->>Storage: public URL 또는 임시 URL 생성
+    Query-->>Client: 이미지 URL 포함 응답
+```
+
+## 운영 체크
+
+| 확인 대상 | 기준 |
+| --- | --- |
+| DB 값 | object key다. 클라이언트 URL과 혼동하지 않는다. |
+| public/private 판별 | object key의 scope prefix가 기준이다. |
+| private URL 발급 | 조회 권한 검증 이후에만 허용한다. |
+| Cache-Control | `public/`은 public cache, `private/`은 no-store다. |
+| WebP object | 원본과 같은 scope에 있어야 한다. |
+| legacy key | 읽기 호환 대상이지만 사용자 식별자 노출 가능성이 있다. |
+| 이전 object 삭제 실패 | 공개범위 변경 결과와 별개로 후속 정리한다. |
+| HeadObject 403 | 객체 없음, 권한, 프록시, CDN 경로 문제를 구분한다. |
+
+## 보안 주의
+
+- private object key를 URL로 바꾸기 전에 Diary 공개범위 정책, 소유자 검증, 친구 관계 검증이 먼저 끝나야 한다.
+- private 임시 URL이 발급됐다는 사실은 접근 권한이 있었다는 증거가 아니다.
+- legacy public object key는 사용자 식별자를 포함할 수 있으므로 익명 일기 또는 비공개 전환과 관련된 경우 보안 부채로 추적한다.
+- legacy object key와 파일명은 필요한 범위에서만 공유한다. 전체 key가 필요하지 않으면 파일명, 일부 prefix, 내부 추적 ID 등으로 축약한다.
+- scope prefix 규칙을 바꾸면 저장, 조회, Cache-Control, WebP 최적화, 공개범위 변경 로직을 함께 검토한다.
+
+## 관련 문서
+
+- Photo WebP Optimization Runbook: 일기 사진 WebP 최적화 스케줄러와 상태 전이 운영 절차
+- MinIO Cloudflare HeadObject Incident: MinIO HeadObject 403 장애 원인과 서버 S3 API endpoint 분리 배경
+- Diary Domain Model: Photo 엔티티의 object key, optimizedUrl, 표시 URL 선택 규칙
+
+## Commit Message
+
+docs: 일기 이미지 저장 운영 현황 정리

--- a/docs/runbooks/photo-webp-optimization-runbook.md
+++ b/docs/runbooks/photo-webp-optimization-runbook.md
@@ -49,9 +49,11 @@
 
 ## 저장 및 캐시 정책
 
-WebP 객체 저장은 `StoreObjectPort.storeObject(file, objectKey)` 경로를 사용한다. 백엔드는 WebP 최적화 작업에서 S3/MinIO `Cache-Control` metadata를 지정하지 않는다.
+WebP 객체 저장은 `StoreObjectPort.storeObject(file, objectKey)` 경로를 사용한다. 백엔드는 object key prefix를 기준으로 S3/MinIO `Cache-Control` metadata를 지정한다.
 
-이미지 캐시 조절은 앞단에서 수행한다. WebP 최적화 작업을 변경할 때도 cache-control 값을 서비스나 저장 요청에 다시 추가하지 않는다.
+`public/` object는 브라우저 캐시 5분, CDN/shared cache 20분 정책을 사용한다. `private/` object는 `no-store` 정책을 사용한다.
+
+WebP object key는 원본 object key와 같은 public/private scope를 유지해야 한다.
 
 ## 운영 확인
 

--- a/src/main/java/com/pikume/back/PikuBackApplication.java
+++ b/src/main/java/com/pikume/back/PikuBackApplication.java
@@ -5,13 +5,14 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import com.pikume.back.diary.adapter.out.cache.ImageCacheProperties;
 import com.pikume.back.diary.application.service.PhotoOptimizationProperties;
 import com.pikume.back.global.storage.StorageProperties;
 
 @SpringBootApplication
 @EnableJpaAuditing
 @EnableScheduling
-@EnableConfigurationProperties({StorageProperties.class, PhotoOptimizationProperties.class})
+@EnableConfigurationProperties({StorageProperties.class, PhotoOptimizationProperties.class, ImageCacheProperties.class})
 public class PikuBackApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/pikume/back/diary/adapter/in/web/DiaryController.java
+++ b/src/main/java/com/pikume/back/diary/adapter/in/web/DiaryController.java
@@ -10,7 +10,6 @@ import com.pikume.back.global.dto.UploadedFileData;
 import com.pikume.back.global.error.CommonProblemType;
 import com.pikume.back.global.error.ProblemDetailFactory;
 import com.pikume.back.global.error.ValidationProblemType;
-import com.pikume.back.global.util.FileUtil;
 import com.pikume.back.global.util.RequestMetaMapper;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -26,8 +25,6 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.core.io.Resource;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -51,7 +48,6 @@ public class DiaryController {
 	private final GetCalendarUseCase getCalendarUseCase;
 	private final UpdateDiaryUseCase updateDiaryUseCase;
 	private final GetDiaryGalleryUseCase getDiaryGalleryUseCase;
-	private final FileUtil fileUtil;
 	private final RequestMetaMapper requestMetaMapper;
 	private final Validator validator;
 	private final ProblemDetailFactory problemDetailFactory;
@@ -98,35 +94,6 @@ public class DiaryController {
 							CommonProblemType.INTERNAL_SERVER_ERROR,
 							"일기 저장 중 오류가 발생했습니다.",
 							"/api/diary"));
-		}
-	}
-
-	@Operation(summary = "일기 이미지 조회", description = "일기에 첨부된 이미지를 조회합니다.")
-	@GetMapping("/images/{userId}/{filename:.+}")
-	public ResponseEntity<?> getFile(@Parameter(description = "사용자 ID") @PathVariable String userId,
-			@Parameter(description = "이미지 파일명") @PathVariable String filename) {
-		log.info("이미지 파일 요청 - userId: {}, filename: {}", userId, filename);
-		try {
-			Resource resource = fileUtil.loadFileAsResource(userId + "/" + filename);
-			String contentType = fileUtil.getContentType(filename);
-
-			return ResponseEntity.ok()
-					.contentType(MediaType.parseMediaType(contentType))
-					.header(HttpHeaders.CONTENT_DISPOSITION, "inline; filename=\"" + resource.getFilename() + "\"")
-					.cacheControl(org.springframework.http.CacheControl
-							.maxAge(1, java.util.concurrent.TimeUnit.DAYS)
-							.cachePublic()
-							.immutable())
-					.body(resource);
-
-		} catch (Exception e) {
-			log.error("이미지 파일 로드 실패 - userId: {}, filename: {}, error: {}", userId, filename, e.getMessage(), e);
-			return ResponseEntity.status(HttpStatus.NOT_FOUND)
-					.contentType(MediaType.APPLICATION_PROBLEM_JSON)
-					.body(problemDetailFactory.create(
-							CommonProblemType.RESOURCE_NOT_FOUND,
-							"이미지 파일을 찾을 수 없습니다.",
-							"/api/diary/images/" + userId + "/" + filename));
 		}
 	}
 

--- a/src/main/java/com/pikume/back/diary/adapter/in/web/problem/DiaryProblemType.java
+++ b/src/main/java/com/pikume/back/diary/adapter/in/web/problem/DiaryProblemType.java
@@ -10,7 +10,11 @@ public enum DiaryProblemType implements ApiProblemType {
 	INVALID_REQUEST("https://api.pikume.com/problems/diary/invalid-request", HttpStatus.BAD_REQUEST, "Bad Request"),
 	NOT_FOUND("https://api.pikume.com/problems/diary/not-found", HttpStatus.NOT_FOUND, "Not Found"),
 	FORBIDDEN("https://api.pikume.com/problems/diary/forbidden", HttpStatus.FORBIDDEN, "Forbidden"),
-	CONFLICT("https://api.pikume.com/problems/diary/conflict", HttpStatus.CONFLICT, "Conflict");
+	CONFLICT("https://api.pikume.com/problems/diary/conflict", HttpStatus.CONFLICT, "Conflict"),
+	IMAGE_RELOCATION_FAILED(
+			"https://api.pikume.com/problems/diary/image-relocation-failed",
+			HttpStatus.INTERNAL_SERVER_ERROR,
+			"Image Relocation Failed");
 
 	private final URI type;
 	private final HttpStatus status;
@@ -42,6 +46,7 @@ public enum DiaryProblemType implements ApiProblemType {
 			case DIARY_INVALID_REQUEST -> INVALID_REQUEST;
 			case DIARY_NOT_FOUND -> NOT_FOUND;
 			case DIARY_ACCESS_DENIED -> FORBIDDEN;
+			case DIARY_IMAGE_RELOCATION_FAILED -> IMAGE_RELOCATION_FAILED;
 			case DUPLICATE_DIARY -> CONFLICT;
 		};
 	}

--- a/src/main/java/com/pikume/back/diary/adapter/out/cache/ImageCacheProperties.java
+++ b/src/main/java/com/pikume/back/diary/adapter/out/cache/ImageCacheProperties.java
@@ -1,0 +1,30 @@
+package com.pikume.back.diary.adapter.out.cache;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "image.cache")
+public class ImageCacheProperties {
+
+	private static final String PUBLIC_PREFIX = "public/";
+	private static final String PRIVATE_PREFIX = "private/";
+
+	private String publicCacheControl = "public, max-age=300, s-maxage=1200";
+	private String privateCacheControl = "private, no-store, max-age=0";
+
+	public String cacheControlForObjectKey(String objectKey) {
+		if (objectKey == null || objectKey.isBlank()) {
+			return null;
+		}
+		if (objectKey.startsWith(PUBLIC_PREFIX)) {
+			return publicCacheControl;
+		}
+		if (objectKey.startsWith(PRIVATE_PREFIX)) {
+			return privateCacheControl;
+		}
+		return null;
+	}
+}

--- a/src/main/java/com/pikume/back/diary/adapter/out/cache/ImageCacheProperties.java
+++ b/src/main/java/com/pikume/back/diary/adapter/out/cache/ImageCacheProperties.java
@@ -1,5 +1,6 @@
 package com.pikume.back.diary.adapter.out.cache;
 
+import com.pikume.back.diary.adapter.out.storage.PhotoObjectKeyConstants;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -9,8 +10,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "image.cache")
 public class ImageCacheProperties {
 
-	private static final String PUBLIC_PREFIX = "public/";
-	private static final String PRIVATE_PREFIX = "private/";
+	private static final String PUBLIC_PREFIX = PhotoObjectKeyConstants.PUBLIC_PREFIX;
+	private static final String PRIVATE_PREFIX = PhotoObjectKeyConstants.PRIVATE_PREFIX;
 
 	private String publicCacheControl = "public, max-age=300, s-maxage=1200";
 	private String privateCacheControl = "private, no-store, max-age=0";

--- a/src/main/java/com/pikume/back/diary/adapter/out/storage/MinioPhotoStorageAdapter.java
+++ b/src/main/java/com/pikume/back/diary/adapter/out/storage/MinioPhotoStorageAdapter.java
@@ -13,10 +13,13 @@ import software.amazon.awssdk.services.s3.model.*;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 import com.pikume.back.creative.application.port.out.CreativeImageStoragePort;
+import com.pikume.back.diary.adapter.out.cache.ImageCacheProperties;
 import com.pikume.back.diary.application.port.out.PhotoStoragePort;
 import com.pikume.back.diary.application.port.out.SaveDiaryPort;
 import com.pikume.back.diary.domain.Diary;
 import com.pikume.back.diary.domain.Photo;
+import com.pikume.back.diary.domain.vo.DiaryPhotoType;
+import com.pikume.back.diary.domain.vo.DiaryVisibility;
 import com.pikume.back.global.dto.UploadedFileData;
 import com.pikume.back.global.port.out.LoadObjectPort;
 import com.pikume.back.global.port.out.ResolveImageUrlPort;
@@ -28,6 +31,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.time.Duration;
+import java.util.Optional;
 
 import static com.pikume.back.diary.adapter.out.storage.PhotoConstants.PUBLIC_PREFIX;
 
@@ -39,14 +43,16 @@ public class MinioPhotoStorageAdapter implements PhotoStoragePort, ResolveImageU
 	private final PhotoUtil photoUtil;
 	private final SaveDiaryPort saveDiaryPort;
 	private final StorageProperties storageProperties;
+	private final ImageCacheProperties imageCacheProperties;
 	private final FileUtil fileUtil;
 
 	public MinioPhotoStorageAdapter(S3Client s3Client, PhotoUtil photoUtil, SaveDiaryPort saveDiaryPort,
-			StorageProperties storageProperties, FileUtil fileUtil) {
+			StorageProperties storageProperties, ImageCacheProperties imageCacheProperties, FileUtil fileUtil) {
 		this.s3Client = s3Client;
 		this.photoUtil = photoUtil;
 		this.saveDiaryPort = saveDiaryPort;
 		this.storageProperties = storageProperties;
+		this.imageCacheProperties = imageCacheProperties;
 		this.fileUtil = fileUtil;
 	}
 
@@ -57,28 +63,23 @@ public class MinioPhotoStorageAdapter implements PhotoStoragePort, ResolveImageU
 		try {
 			if (!photo.isEmpty()) {
 				String originalFilename = photo.originalFilename();
-				String filename = photoUtil.generateFileName(diary.getDate(), originalFilename);
-				boolean isPublic = (order != null && order == 0);
-				String objectName = isPublic ? PUBLIC_PREFIX + userId + "/" + filename : userId + "/" + filename;
+				boolean isPublic = isPublicDiary(diary.getStatus());
+				String objectName = photoUtil.generateDiaryUserImageObjectKey(isPublic, originalFilename);
 
 				ensureBucketExists(storageProperties.getBucket());
 
-				PutObjectRequest.Builder requestBuilder = PutObjectRequest.builder()
+				PutObjectRequest putObjectRequest = PutObjectRequest.builder()
 						.bucket(storageProperties.getBucket())
 						.key(objectName)
 						.contentType(photo.contentType())
-						.contentLength(photo.size());
-
-				if (isPublic) {
-					requestBuilder.cacheControl("public, max-age=31536000, immutable");
-				}
-
-				PutObjectRequest putObjectRequest = requestBuilder.build();
+						.cacheControl(cacheControlFor(objectName))
+						.contentLength(photo.size())
+						.build();
 
 				s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(photo.inputStream(), photo.size()));
 
-				Photo savePhoto = new Photo(diary, objectName, order);
-				if (isPublic) {
+				Photo savePhoto = new Photo(diary, objectName, order, DiaryPhotoType.USER_IMAGE);
+				if (isRepresent(order)) {
 					savePhoto.updateRepresent(true);
 				}
 				saveDiaryPort.savePhoto(savePhoto);
@@ -102,8 +103,9 @@ public class MinioPhotoStorageAdapter implements PhotoStoragePort, ResolveImageU
 					.contentType(image.contentType())
 					.contentLength(image.size());
 
-			if (cacheControl != null && !cacheControl.isBlank()) {
-				requestBuilder.cacheControl(cacheControl);
+			String effectiveCacheControl = hasText(cacheControl) ? cacheControl : cacheControlFor(objectKey);
+			if (hasText(effectiveCacheControl)) {
+				requestBuilder.cacheControl(effectiveCacheControl);
 			}
 
 			PutObjectRequest putObjectRequest = requestBuilder.build();
@@ -196,10 +198,14 @@ public class MinioPhotoStorageAdapter implements PhotoStoragePort, ResolveImageU
 
 	@Override
 	public String getPhotoUrl(String objectName, boolean isPublic) {
+		if (objectName == null || objectName.isBlank()) {
+			return null;
+		}
+		boolean publicObject = isPublicObjectKey(objectName);
 		String storageType = storageProperties.getType();
 		if ("minio".equalsIgnoreCase(storageType)) {
 			try {
-				return getMinIOStoragePhotoUrl(objectName, isPublic);
+				return getMinIOStoragePhotoUrl(objectName, publicObject);
 			} catch (Exception e) {
 				log.error("MinIO에서 미리 서명된 URL 생성 실패: {}", e.getMessage(), e);
 				return null;
@@ -235,11 +241,10 @@ public class MinioPhotoStorageAdapter implements PhotoStoragePort, ResolveImageU
 			}
 
 			String cleanExtension = fileUtil.cleanExtension(fileExtension);
-			String fileName = fileUtil.generateUniqueFileNameWithExtension(cleanExtension);
 			byte[] imageBytes = fileUtil.decodeBase64(base64Data);
 			ByteArrayInputStream inputStream = new ByteArrayInputStream(imageBytes);
 
-			String objectName = userId + "/" + fileName;
+			String objectName = photoUtil.generateDiaryAiImageObjectKey(cleanExtension);
 
 			ensureBucketExists(storageProperties.getBucket());
 
@@ -247,11 +252,12 @@ public class MinioPhotoStorageAdapter implements PhotoStoragePort, ResolveImageU
 					.bucket(storageProperties.getBucket())
 					.key(objectName)
 					.contentType(fileUtil.getContentType(cleanExtension))
+					.cacheControl(cacheControlFor(objectName))
 					.build();
 
 			s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(inputStream, imageBytes.length));
 
-			log.info("Base64 이미지 저장 완료 - 사용자: {}, 파일: {}, 크기: {} bytes", userId, fileName, imageBytes.length);
+			log.info("Base64 이미지 저장 완료 - 사용자: {}, objectKey: {}, 크기: {} bytes", userId, objectName, imageBytes.length);
 			return objectName;
 
 		} catch (IllegalArgumentException e) {
@@ -265,48 +271,70 @@ public class MinioPhotoStorageAdapter implements PhotoStoragePort, ResolveImageU
 
 	@Override
 	public String moveToPublic(String sourceKey) {
-		String targetKey = PUBLIC_PREFIX + sourceKey;
+		String targetKey = photoUtil.publicObjectKeyFor(sourceKey);
+		return copyObject(sourceKey, targetKey, true);
+	}
+
+	@Override
+	public String copyToVisibilityScope(String sourceKey, DiaryVisibility visibility, DiaryPhotoType sourceType) {
+		String targetKey = photoUtil.visibilityObjectKeyFor(sourceKey, isPublicDiary(visibility), sourceType);
+		return copyObject(sourceKey, targetKey, false);
+	}
+
+	private String copyObject(String sourceKey, String targetKey, boolean deleteSource) {
 		boolean fileCopied = false;
 
 		try {
-			if (sourceKey.startsWith(PUBLIC_PREFIX)) {
-				log.info("이미 public 경로입니다: {}", sourceKey);
+			if (sourceKey.equals(targetKey)) {
+				log.info("이미 대상 경로입니다: {}", sourceKey);
 				return sourceKey;
 			}
 
-			if (objectExists(targetKey)) {
-				log.info("public 경로에 이미 파일이 존재합니다. 원본 삭제: {}", sourceKey);
-				deleteObject(sourceKey);
+			if (objectHead(targetKey).isPresent()) {
+				log.info("대상 경로에 이미 파일이 존재합니다. sourceKey: {}, targetKey: {}", sourceKey, targetKey);
+				if (deleteSource) {
+					deleteObject(sourceKey);
+				}
 				return targetKey;
 			}
 
-			if (!objectExists(sourceKey)) {
-				log.error("소스 파일이 존재하지 않습니다: {}", sourceKey);
-				throw new RuntimeException("소스 파일을 찾을 수 없습니다: " + sourceKey);
-			}
+			HeadObjectResponse sourceHead = objectHead(sourceKey)
+					.orElseThrow(() -> {
+						log.error("소스 파일이 존재하지 않습니다: {}", sourceKey);
+						return new RuntimeException("소스 파일을 찾을 수 없습니다: " + sourceKey);
+					});
 
-			CopyObjectRequest copyRequest = CopyObjectRequest.builder()
+			CopyObjectRequest.Builder copyRequestBuilder = CopyObjectRequest.builder()
 					.sourceBucket(storageProperties.getBucket())
 					.sourceKey(sourceKey)
 					.destinationBucket(storageProperties.getBucket())
 					.destinationKey(targetKey)
-					.cacheControl("public, max-age=31536000, immutable")
-					.build();
+					.metadataDirective(MetadataDirective.REPLACE)
+					.cacheControl(cacheControlFor(targetKey));
 
-			s3Client.copyObject(copyRequest);
+			if (hasText(sourceHead.contentType())) {
+				copyRequestBuilder.contentType(sourceHead.contentType());
+			}
+			if (sourceHead.metadata() != null && !sourceHead.metadata().isEmpty()) {
+				copyRequestBuilder.metadata(sourceHead.metadata());
+			}
+
+			s3Client.copyObject(copyRequestBuilder.build());
 			fileCopied = true;
 
 			if (!objectExists(targetKey)) {
 				throw new RuntimeException("파일 복사 후 확인 실패: " + targetKey);
 			}
 
-			deleteObject(sourceKey);
+			if (deleteSource) {
+				deleteObject(sourceKey);
+			}
 
-			log.info("파일 이동 완료: {} → {} (원본 삭제됨)", sourceKey, targetKey);
+			log.info("파일 복제 완료: {} → {} (원본 삭제 여부: {})", sourceKey, targetKey, deleteSource);
 			return targetKey;
 
 		} catch (S3Exception e) {
-			log.error("S3 파일 이동 실패: {} → {}, 오류: {}", sourceKey, targetKey, e.getMessage(), e);
+			log.error("S3 파일 복제 실패: {} → {}, 오류: {}", sourceKey, targetKey, e.getMessage(), e);
 
 			if (fileCopied) {
 				try {
@@ -320,9 +348,9 @@ public class MinioPhotoStorageAdapter implements PhotoStoragePort, ResolveImageU
 				}
 			}
 
-			throw new RuntimeException("파일 이동 중 오류가 발생했습니다.", e);
+			throw new RuntimeException("파일 복제 중 오류가 발생했습니다.", e);
 		} catch (Exception e) {
-			log.error("파일 이동 중 예상하지 못한 오류 발생: {}", e.getMessage(), e);
+			log.error("파일 복제 중 예상하지 못한 오류 발생: {}", e.getMessage(), e);
 
 			if (fileCopied) {
 				try {
@@ -336,24 +364,39 @@ public class MinioPhotoStorageAdapter implements PhotoStoragePort, ResolveImageU
 				}
 			}
 
-			throw new RuntimeException("파일 이동 중 오류가 발생했습니다.", e);
+			throw new RuntimeException("파일 복제 중 오류가 발생했습니다.", e);
 		}
 	}
 
+	private boolean isPublicDiary(DiaryVisibility visibility) {
+		return visibility == DiaryVisibility.PUBLIC || visibility == DiaryVisibility.ANONYMOUS;
+	}
+
+	private boolean isRepresent(Integer order) {
+		return order != null && order == 0;
+	}
+
+	private boolean isPublicObjectKey(String objectName) {
+		return objectName.startsWith(PUBLIC_PREFIX);
+	}
+
 	private boolean objectExists(String key) {
+		return objectHead(key).isPresent();
+	}
+
+	private Optional<HeadObjectResponse> objectHead(String key) {
 		try {
 			HeadObjectRequest request = HeadObjectRequest.builder()
 					.bucket(storageProperties.getBucket())
 					.key(key)
 					.build();
 
-			s3Client.headObject(request);
-			return true;
+			return Optional.of(s3Client.headObject(request));
 		} catch (NoSuchKeyException e) {
-			return false;
+			return Optional.empty();
 		} catch (S3Exception e) {
 			if (e.statusCode() == 404) {
-				return false;
+				return Optional.empty();
 			}
 			log.warn("event=storage_object_exists_failed outcome=failed key={} status={} reason={}",
 					key,
@@ -363,7 +406,16 @@ public class MinioPhotoStorageAdapter implements PhotoStoragePort, ResolveImageU
 		}
 	}
 
-	private void deleteObject(String key) {
+	private String cacheControlFor(String objectKey) {
+		return imageCacheProperties.cacheControlForObjectKey(objectKey);
+	}
+
+	private boolean hasText(String value) {
+		return value != null && !value.isBlank();
+	}
+
+	@Override
+	public void deleteObject(String key) {
 		try {
 			DeleteObjectRequest request = DeleteObjectRequest.builder()
 					.bucket(storageProperties.getBucket())

--- a/src/main/java/com/pikume/back/diary/adapter/out/storage/MinioPhotoStorageAdapter.java
+++ b/src/main/java/com/pikume/back/diary/adapter/out/storage/MinioPhotoStorageAdapter.java
@@ -33,7 +33,7 @@ import java.net.URI;
 import java.time.Duration;
 import java.util.Optional;
 
-import static com.pikume.back.diary.adapter.out.storage.PhotoConstants.PUBLIC_PREFIX;
+import static com.pikume.back.diary.adapter.out.storage.PhotoObjectKeyConstants.PUBLIC_PREFIX;
 
 @Slf4j
 @Component

--- a/src/main/java/com/pikume/back/diary/adapter/out/storage/MinioPhotoStorageAdapter.java
+++ b/src/main/java/com/pikume/back/diary/adapter/out/storage/MinioPhotoStorageAdapter.java
@@ -1,17 +1,5 @@
 package com.pikume.back.diary.adapter.out.storage;
 
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Component;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
-import software.amazon.awssdk.core.ResponseBytes;
-import software.amazon.awssdk.core.sync.RequestBody;
-import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.S3Configuration;
-import software.amazon.awssdk.services.s3.model.*;
-import software.amazon.awssdk.services.s3.presigner.S3Presigner;
-import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 import com.pikume.back.creative.application.port.out.CreativeImageStoragePort;
 import com.pikume.back.diary.adapter.out.cache.ImageCacheProperties;
 import com.pikume.back.diary.application.port.out.PhotoStoragePort;
@@ -26,9 +14,20 @@ import com.pikume.back.global.port.out.ResolveImageUrlPort;
 import com.pikume.back.global.port.out.StoreObjectPort;
 import com.pikume.back.global.storage.StorageProperties;
 import com.pikume.back.global.util.FileUtil;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.model.*;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.net.URI;
 import java.time.Duration;
 import java.util.Optional;
@@ -57,7 +56,7 @@ public class MinioPhotoStorageAdapter implements PhotoStoragePort, ResolveImageU
 	}
 
 	@Override
-	public void savePhoto(Diary diary, UploadedFileData photo, String userId, Integer order) throws IOException {
+	public void savePhoto(Diary diary, UploadedFileData photo, String userId, Integer order) {
 		log.info("사진 S3 저장 시작 - 사용자: {}, 일기 날짜: {}", userId, diary.getDate());
 
 		try {
@@ -162,7 +161,7 @@ public class MinioPhotoStorageAdapter implements PhotoStoragePort, ResolveImageU
 		}
 	}
 
-	public String getMinIOStoragePhotoUrl(String objectName, boolean isPublic) throws Exception {
+	public String getMinIOStoragePhotoUrl(String objectName, boolean isPublic) {
 		String clientToS3BaseUrl = storageProperties.clientToS3BaseUrl();
 		if (isPublic) {
 			return clientToS3BaseUrl + "/" + storageProperties.getBucket() + "/" + objectName;

--- a/src/main/java/com/pikume/back/diary/adapter/out/storage/PhotoConstants.java
+++ b/src/main/java/com/pikume/back/diary/adapter/out/storage/PhotoConstants.java
@@ -2,6 +2,7 @@ package com.pikume.back.diary.adapter.out.storage;
 
 public class PhotoConstants {
 	public static final String PUBLIC_PREFIX = "public/";
+	public static final String PRIVATE_PREFIX = "private/";
 
 	// 인스턴스화 방지
 	private PhotoConstants() {

--- a/src/main/java/com/pikume/back/diary/adapter/out/storage/PhotoObjectKeyConstants.java
+++ b/src/main/java/com/pikume/back/diary/adapter/out/storage/PhotoObjectKeyConstants.java
@@ -1,10 +1,10 @@
 package com.pikume.back.diary.adapter.out.storage;
 
-public class PhotoConstants {
+public class PhotoObjectKeyConstants {
 	public static final String PUBLIC_PREFIX = "public/";
 	public static final String PRIVATE_PREFIX = "private/";
 
 	// 인스턴스화 방지
-	private PhotoConstants() {
+	private PhotoObjectKeyConstants() {
 	}
 }

--- a/src/main/java/com/pikume/back/diary/adapter/out/storage/PhotoUtil.java
+++ b/src/main/java/com/pikume/back/diary/adapter/out/storage/PhotoUtil.java
@@ -4,9 +4,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import com.pikume.back.diary.domain.vo.DiaryPhotoType;
 
-import java.time.LocalDate;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import java.util.Locale;
 import java.util.UUID;
 
@@ -21,27 +18,6 @@ public class PhotoUtil {
 	private static final String USER_IMAGE_SEGMENT = "user";
 	private static final String AI_IMAGE_SEGMENT = "ai";
 
-	public String generateFileName(LocalDate diaryDate, String originalFilename) {
-		String date = diaryDate
-				.atStartOfDay(ZoneId.systemDefault())
-				.toLocalDate()
-				.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
-		log.info("파일명 생성 - 현재 등록하는 일기날짜: {}", diaryDate);
-
-		String uuid = UUID.randomUUID().toString().substring(0, 8);
-
-		String extension = "";
-
-		int dotIndex = originalFilename.lastIndexOf(".");
-		if (dotIndex > 0) {
-			extension = originalFilename.substring(dotIndex);
-		}
-
-		String fileName = date + "_" + uuid + extension;
-		log.info("파일명 생성완료  - 생성명:{} ", fileName);
-		return fileName;
-	}
-
 	public String generateDiaryUserImageObjectKey(boolean publicAccess, String originalFilename) {
 		return generateDiaryImageObjectKey(publicAccess, USER_IMAGE_SEGMENT, extensionFromOriginalFilename(originalFilename));
 	}
@@ -53,10 +29,6 @@ public class PhotoUtil {
 
 	public String publicObjectKeyFor(String objectKey) {
 		return objectKeyForPrefix(objectKey, PUBLIC_PREFIX);
-	}
-
-	public String privateObjectKeyFor(String objectKey) {
-		return objectKeyForPrefix(objectKey, PRIVATE_PREFIX);
 	}
 
 	public String visibilityObjectKeyFor(String objectKey, boolean publicAccess, DiaryPhotoType sourceType) {

--- a/src/main/java/com/pikume/back/diary/adapter/out/storage/PhotoUtil.java
+++ b/src/main/java/com/pikume/back/diary/adapter/out/storage/PhotoUtil.java
@@ -10,8 +10,8 @@ import java.time.format.DateTimeFormatter;
 import java.util.Locale;
 import java.util.UUID;
 
-import static com.pikume.back.diary.adapter.out.storage.PhotoConstants.PRIVATE_PREFIX;
-import static com.pikume.back.diary.adapter.out.storage.PhotoConstants.PUBLIC_PREFIX;
+import static com.pikume.back.diary.adapter.out.storage.PhotoObjectKeyConstants.PRIVATE_PREFIX;
+import static com.pikume.back.diary.adapter.out.storage.PhotoObjectKeyConstants.PUBLIC_PREFIX;
 
 @Slf4j
 @Service

--- a/src/main/java/com/pikume/back/diary/adapter/out/storage/PhotoUtil.java
+++ b/src/main/java/com/pikume/back/diary/adapter/out/storage/PhotoUtil.java
@@ -2,19 +2,24 @@ package com.pikume.back.diary.adapter.out.storage;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import com.pikume.back.global.dto.UploadedFileData;
-import com.pikume.back.global.util.FileConstants;
+import com.pikume.back.diary.domain.vo.DiaryPhotoType;
 
-import java.io.File;
-import java.io.IOException;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 import java.util.UUID;
+
+import static com.pikume.back.diary.adapter.out.storage.PhotoConstants.PRIVATE_PREFIX;
+import static com.pikume.back.diary.adapter.out.storage.PhotoConstants.PUBLIC_PREFIX;
 
 @Slf4j
 @Service
 public class PhotoUtil {
+
+	private static final String DIARY_IMAGE_ROOT = "diary-images";
+	private static final String USER_IMAGE_SEGMENT = "user";
+	private static final String AI_IMAGE_SEGMENT = "ai";
 
 	public String generateFileName(LocalDate diaryDate, String originalFilename) {
 		String date = diaryDate
@@ -37,23 +42,98 @@ public class PhotoUtil {
 		return fileName;
 	}
 
-	public String getDefaultPath() {
-		return System.getProperty("user.dir");
+	public String generateDiaryUserImageObjectKey(boolean publicAccess, String originalFilename) {
+		return generateDiaryImageObjectKey(publicAccess, USER_IMAGE_SEGMENT, extensionFromOriginalFilename(originalFilename));
 	}
 
-	public String saveToLocal(UploadedFileData photos, String userId, String filename) throws IOException {
-		String uploadPath = FileConstants.UPLOADS_BASE_DIR_NAME + "/" + userId;
-		String uploadDir = getDefaultPath() + "/" + uploadPath;
+	public String generateDiaryAiImageObjectKey(String cleanExtension) {
+		String extension = normalizeExtension(cleanExtension);
+		return generateDiaryImageObjectKey(false, AI_IMAGE_SEGMENT, extension);
+	}
 
-		new File(uploadDir).mkdirs();
-		File destination = new File(uploadDir, filename);
+	public String publicObjectKeyFor(String objectKey) {
+		return objectKeyForPrefix(objectKey, PUBLIC_PREFIX);
+	}
 
-		log.info("파일 저장 시작 - 저장 경로: {}", destination);
-		try (var inputStream = photos.inputStream()) {
-			java.nio.file.Files.copy(inputStream, destination.toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+	public String privateObjectKeyFor(String objectKey) {
+		return objectKeyForPrefix(objectKey, PRIVATE_PREFIX);
+	}
+
+	public String visibilityObjectKeyFor(String objectKey, boolean publicAccess, DiaryPhotoType sourceType) {
+		if (isDiaryImageObjectKey(objectKey)) {
+			return objectKeyForPrefix(objectKey, publicAccess ? PUBLIC_PREFIX : PRIVATE_PREFIX);
 		}
-
-		log.info("파일 저장 완료 - 저장 경로: {}", destination);
-		return userId + "/" + filename;
+		return generateDiaryImageObjectKey(publicAccess, sourceSegment(sourceType), extensionFromObjectKey(objectKey));
 	}
+
+	private String generateDiaryImageObjectKey(boolean publicAccess, String sourceSegment, String extension) {
+		String uuid = UUID.randomUUID().toString().replace("-", "");
+		String prefix = publicAccess ? PUBLIC_PREFIX : PRIVATE_PREFIX;
+
+		return prefix + DIARY_IMAGE_ROOT + "/"
+				+ sourceSegment + "/"
+				+ uuid.substring(0, 2) + "/"
+				+ uuid.substring(2, 4) + "/"
+				+ uuid + extension;
+	}
+
+	private String objectKeyForPrefix(String objectKey, String targetPrefix) {
+		if (objectKey == null || objectKey.isBlank()) {
+			throw new IllegalArgumentException("objectKey는 필수입니다.");
+		}
+		if (objectKey.startsWith(targetPrefix)) {
+			return objectKey;
+		}
+		if (objectKey.startsWith(PUBLIC_PREFIX)) {
+			return targetPrefix + objectKey.substring(PUBLIC_PREFIX.length());
+		}
+		if (objectKey.startsWith(PRIVATE_PREFIX)) {
+			return targetPrefix + objectKey.substring(PRIVATE_PREFIX.length());
+		}
+		return targetPrefix + objectKey;
+	}
+
+	private boolean isDiaryImageObjectKey(String objectKey) {
+		return objectKey != null
+				&& (objectKey.startsWith(PUBLIC_PREFIX + DIARY_IMAGE_ROOT + "/")
+				|| objectKey.startsWith(PRIVATE_PREFIX + DIARY_IMAGE_ROOT + "/"));
+	}
+
+	private String sourceSegment(DiaryPhotoType sourceType) {
+		if (sourceType == DiaryPhotoType.AI_IMAGE) {
+			return AI_IMAGE_SEGMENT;
+		}
+		return USER_IMAGE_SEGMENT;
+	}
+
+	private String extensionFromOriginalFilename(String originalFilename) {
+		if (originalFilename == null || originalFilename.isBlank()) {
+			return "";
+		}
+		int dotIndex = originalFilename.lastIndexOf(".");
+		if (dotIndex < 0 || dotIndex == originalFilename.length() - 1) {
+			return "";
+		}
+		return normalizeExtension(originalFilename.substring(dotIndex + 1));
+	}
+
+	private String extensionFromObjectKey(String objectKey) {
+		if (objectKey == null || objectKey.isBlank()) {
+			return "";
+		}
+		int queryIndex = objectKey.indexOf('?');
+		String path = queryIndex >= 0 ? objectKey.substring(0, queryIndex) : objectKey;
+		int slashIndex = path.lastIndexOf('/');
+		String filename = slashIndex >= 0 ? path.substring(slashIndex + 1) : path;
+		return extensionFromOriginalFilename(filename);
+	}
+
+	private String normalizeExtension(String extension) {
+		if (extension == null || extension.isBlank()) {
+			return "";
+		}
+		String normalized = extension.startsWith(".") ? extension.substring(1) : extension;
+		return "." + normalized.toLowerCase(Locale.ROOT);
+	}
+
 }

--- a/src/main/java/com/pikume/back/diary/application/exception/DiaryErrorCode.java
+++ b/src/main/java/com/pikume/back/diary/application/exception/DiaryErrorCode.java
@@ -9,6 +9,7 @@ public enum DiaryErrorCode {
 	DIARY_NOT_FOUND("해당 일기 목록이 존재하지 않습니다."),
 	DIARY_ACCESS_DENIED("해당 일기에 대한 권한이 없습니다."),
 	DIARY_INVALID_REQUEST("일기 요청 값이 올바르지 않습니다."),
+	DIARY_IMAGE_RELOCATION_FAILED("일기 이미지 공개범위 변경에 실패했습니다."),
 	DUPLICATE_DIARY("이미 해당 날짜에 일기가 존재합니다: %s");
 
 	private final String message;

--- a/src/main/java/com/pikume/back/diary/application/exception/DiaryException.java
+++ b/src/main/java/com/pikume/back/diary/application/exception/DiaryException.java
@@ -16,4 +16,9 @@ public class DiaryException extends RuntimeException {
 		super(message);
 		this.errorCode = errorCode;
 	}
+
+	public DiaryException(DiaryErrorCode errorCode, String message, Throwable cause) {
+		super(message, cause);
+		this.errorCode = errorCode;
+	}
 }

--- a/src/main/java/com/pikume/back/diary/application/exception/DiaryImageRelocationException.java
+++ b/src/main/java/com/pikume/back/diary/application/exception/DiaryImageRelocationException.java
@@ -1,0 +1,12 @@
+package com.pikume.back.diary.application.exception;
+
+public class DiaryImageRelocationException extends DiaryException {
+
+	public DiaryImageRelocationException(String message) {
+		super(DiaryErrorCode.DIARY_IMAGE_RELOCATION_FAILED, message);
+	}
+
+	public DiaryImageRelocationException(String message, Throwable cause) {
+		super(DiaryErrorCode.DIARY_IMAGE_RELOCATION_FAILED, message, cause);
+	}
+}

--- a/src/main/java/com/pikume/back/diary/application/port/out/PhotoStoragePort.java
+++ b/src/main/java/com/pikume/back/diary/application/port/out/PhotoStoragePort.java
@@ -1,6 +1,8 @@
 package com.pikume.back.diary.application.port.out;
 
 import com.pikume.back.diary.domain.Diary;
+import com.pikume.back.diary.domain.vo.DiaryPhotoType;
+import com.pikume.back.diary.domain.vo.DiaryVisibility;
 import com.pikume.back.global.dto.UploadedFileData;
 
 import java.io.IOException;
@@ -11,6 +13,10 @@ public interface PhotoStoragePort {
 	String getPhotoUrl(String objectName, boolean isPublic);
 
 	String moveToPublic(String sourceKey);
+
+	String copyToVisibilityScope(String sourceKey, DiaryVisibility visibility, DiaryPhotoType sourceType);
+
+	void deleteObject(String objectKey);
 
 	String saveAIPhoto(String base64Data, String userId, String fileExtension);
 }

--- a/src/main/java/com/pikume/back/diary/application/service/DiaryCommandService.java
+++ b/src/main/java/com/pikume/back/diary/application/service/DiaryCommandService.java
@@ -12,6 +12,7 @@ import com.pikume.back.diary.application.dto.DiaryImageCommand;
 import com.pikume.back.diary.application.dto.DiaryUpdatedResult;
 import com.pikume.back.diary.application.dto.UpdateDiaryCommand;
 import com.pikume.back.diary.application.exception.DiaryAccessDeniedException;
+import com.pikume.back.diary.application.exception.DiaryImageRelocationException;
 import com.pikume.back.diary.application.exception.DiaryInvalidRequestException;
 import com.pikume.back.diary.application.exception.DiaryNotFoundException;
 import com.pikume.back.diary.application.exception.DuplicateDiaryException;
@@ -33,7 +34,9 @@ import java.io.IOException;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -71,12 +74,175 @@ public class DiaryCommandService implements CreateDiaryUseCase, DeleteDiaryUseCa
 		}
 
 		Diary diary = loadOwnedDiary(diaryId, userId);
-		diary.updateContentAndStatus(command.content(), command.status());
-		Diary savedDiary = saveDiaryPort.save(diary);
-		log.info("사용자 [{}] - 일기 ID [{}] 수정 완료", userId, diaryId);
-		analyzeDiaryMetadataAfterCommit(savedDiary);
+		ImageRelocationResult relocationResult = ImageRelocationResult.empty();
+		try {
+			relocationResult = relocatePhotosForVisibilityChange(diary, command.status());
+			diary.updateContentAndStatus(command.content(), command.status());
+			Diary savedDiary = saveDiaryPort.save(diary);
+			registerImageRelocationCleanup(relocationResult);
+			log.info("사용자 [{}] - 일기 ID [{}] 수정 완료", userId, diaryId);
+			analyzeDiaryMetadataAfterCommit(savedDiary);
 
-		return new DiaryUpdatedResult(savedDiary.getId(), savedDiary.getStatus(), savedDiary.getContent());
+			return new DiaryUpdatedResult(savedDiary.getId(), savedDiary.getStatus(), savedDiary.getContent());
+		} catch (RuntimeException e) {
+			deleteCopiedObjectsForRollback(relocationResult.copiedObjectKeys());
+			throw e;
+		}
+	}
+
+	private ImageRelocationResult relocatePhotosForVisibilityChange(Diary diary, DiaryVisibility targetVisibility) {
+		if (isPublicDiary(diary.getStatus()) == isPublicDiary(targetVisibility)) {
+			return ImageRelocationResult.empty();
+		}
+
+		List<Photo> photos = loadDiaryPort.findPhotosByDiaryIds(Set.of(diary.getId()));
+		if (photos.isEmpty()) {
+			return ImageRelocationResult.empty();
+		}
+
+		List<PhotoScopeTransition> transitions = new ArrayList<>();
+		List<String> copiedObjectKeys = new ArrayList<>();
+		try {
+			for (Photo photo : photos) {
+				PhotoScopeTransition transition = copyPhotoToVisibilityScope(photo, targetVisibility, copiedObjectKeys);
+				if (transition.hasChanged()) {
+					transitions.add(transition);
+				}
+			}
+
+			for (PhotoScopeTransition transition : transitions) {
+				transition.apply();
+				saveDiaryPort.savePhoto(transition.photo());
+			}
+
+			return new ImageRelocationResult(
+					List.copyOf(new LinkedHashSet<>(copiedObjectKeys)),
+					oldObjectKeysToDelete(transitions));
+		} catch (DiaryImageRelocationException e) {
+			deleteCopiedObjectsForRollback(copiedObjectKeys);
+			throw e;
+		} catch (RuntimeException e) {
+			deleteCopiedObjectsForRollback(copiedObjectKeys);
+			throw new DiaryImageRelocationException("일기 이미지 공개범위 변경 중 오류가 발생했습니다.", e);
+		}
+	}
+
+	private PhotoScopeTransition copyPhotoToVisibilityScope(
+			Photo photo,
+			DiaryVisibility targetVisibility,
+			List<String> copiedObjectKeys) {
+		String oldUrl = photo.getUrl();
+		String newUrl = copyObjectToVisibilityScope(oldUrl, targetVisibility, photo.getSourceType(), copiedObjectKeys);
+
+		String oldOptimizedUrl = photo.getOptimizedUrl();
+		String newOptimizedUrl = oldOptimizedUrl;
+		if (hasText(oldOptimizedUrl)) {
+			if (Objects.equals(oldOptimizedUrl, oldUrl)) {
+				newOptimizedUrl = newUrl;
+			} else {
+				newOptimizedUrl = copyObjectToVisibilityScope(
+						oldOptimizedUrl,
+						targetVisibility,
+						photo.getSourceType(),
+						copiedObjectKeys);
+			}
+		}
+
+		return new PhotoScopeTransition(photo, oldUrl, newUrl, oldOptimizedUrl, newOptimizedUrl);
+	}
+
+	private String copyObjectToVisibilityScope(
+			String objectKey,
+			DiaryVisibility targetVisibility,
+			DiaryPhotoType sourceType,
+			List<String> copiedObjectKeys) {
+		if (!hasText(objectKey)) {
+			return objectKey;
+		}
+
+		String copiedObjectKey = photoStoragePort.copyToVisibilityScope(objectKey, targetVisibility, sourceType);
+		if (!Objects.equals(objectKey, copiedObjectKey)) {
+			copiedObjectKeys.add(copiedObjectKey);
+		}
+		return copiedObjectKey;
+	}
+
+	private List<String> oldObjectKeysToDelete(List<PhotoScopeTransition> transitions) {
+		LinkedHashSet<String> objectKeys = new LinkedHashSet<>();
+		for (PhotoScopeTransition transition : transitions) {
+			for (String oldObjectKey : transition.oldObjectKeys()) {
+				if (hasText(oldObjectKey) && !transition.newObjectKeys().contains(oldObjectKey)) {
+					objectKeys.add(oldObjectKey);
+				}
+			}
+		}
+		return List.copyOf(objectKeys);
+	}
+
+	private void registerImageRelocationCleanup(ImageRelocationResult relocationResult) {
+		if (relocationResult.isEmpty()) {
+			return;
+		}
+
+		if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+			deleteOldObjectsForAdminCleanup(relocationResult.oldObjectKeys());
+			return;
+		}
+
+		TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+			@Override
+			public void afterCommit() {
+				deleteOldObjectsForAdminCleanup(relocationResult.oldObjectKeys());
+			}
+
+			@Override
+			public void afterCompletion(int status) {
+				if (status != STATUS_COMMITTED) {
+					deleteCopiedObjectsForRollback(relocationResult.copiedObjectKeys());
+				}
+			}
+		});
+	}
+
+	private void deleteCopiedObjectsForRollback(List<String> objectKeys) {
+		deleteObjects(objectKeys, "image_relocation_copied_object_cleanup_failed");
+	}
+
+	private void deleteOldObjectsForAdminCleanup(List<String> objectKeys) {
+		deleteObjects(objectKeys, "image_relocation_old_object_cleanup_failed");
+	}
+
+	private void deleteObjects(List<String> objectKeys, String eventName) {
+		if (objectKeys == null || objectKeys.isEmpty()) {
+			return;
+		}
+		for (String objectKey : new LinkedHashSet<>(objectKeys)) {
+			try {
+				photoStoragePort.deleteObject(objectKey);
+			} catch (RuntimeException e) {
+				log.error("event={} outcome=failed objectKey={} fileName={} reason={}",
+						eventName,
+						objectKey,
+						fileNameFromObjectKey(objectKey),
+						e.getMessage(),
+						e);
+			}
+		}
+	}
+
+	private String fileNameFromObjectKey(String objectKey) {
+		if (!hasText(objectKey)) {
+			return "";
+		}
+		int slashIndex = objectKey.lastIndexOf('/');
+		if (slashIndex < 0 || slashIndex == objectKey.length() - 1) {
+			return objectKey;
+		}
+		return objectKey.substring(slashIndex + 1);
+	}
+
+	private boolean hasText(String value) {
+		return value != null && !value.isBlank();
 	}
 
 	private Diary loadOwnedDiary(Long diaryId, String userId) {
@@ -162,17 +328,17 @@ public class DiaryCommandService implements CreateDiaryUseCase, DeleteDiaryUseCa
 			var diaryImageGeneration = loadCreativePort.findById(aiPhoto);
 			String filePath = diaryImageGeneration.filePath();
 
-			boolean isRepresent = (order != null && order == 0);
-			if (isRepresent) {
+			if (isPublicDiary(diary.getStatus())) {
 				String oldPath = filePath;
 				filePath = photoStoragePort.moveToPublic(filePath);
-				log.info("대표 사진을 public 경로로 이동 완료: {} → {}", oldPath, filePath);
+				log.info("공개 일기 AI 사진을 public 경로로 이동 완료: {} → {}", oldPath, filePath);
 
 				loadCreativePort.updateFilePath(aiPhoto, filePath);
 				log.info("DiaryImageGeneration filePath 업데이트 완료 (ID: {})", aiPhoto);
 			}
 
-			Photo savePhoto = new Photo(diary, filePath, order);
+			boolean isRepresent = (order != null && order == 0);
+			Photo savePhoto = new Photo(diary, filePath, order, DiaryPhotoType.AI_IMAGE);
 			if (isRepresent) {
 				savePhoto.updateRepresent(true);
 			}
@@ -182,6 +348,59 @@ public class DiaryCommandService implements CreateDiaryUseCase, DeleteDiaryUseCa
 			log.info("AI 사진 저장 완료 - 경로: {}, 대표사진: {}", filePath, isRepresent);
 		} else {
 			log.warn("빈 AI 사진 ID 발견 - 사용자: {}, 일기 날짜: {}", userId, diary.getDate());
+		}
+	}
+
+	private boolean isPublicDiary(DiaryVisibility visibility) {
+		return visibility == DiaryVisibility.PUBLIC || visibility == DiaryVisibility.ANONYMOUS;
+	}
+
+	private record ImageRelocationResult(List<String> copiedObjectKeys, List<String> oldObjectKeys) {
+
+		private static ImageRelocationResult empty() {
+			return new ImageRelocationResult(List.of(), List.of());
+		}
+
+		private boolean isEmpty() {
+			return copiedObjectKeys.isEmpty() && oldObjectKeys.isEmpty();
+		}
+	}
+
+	private record PhotoScopeTransition(
+			Photo photo,
+			String oldUrl,
+			String newUrl,
+			String oldOptimizedUrl,
+			String newOptimizedUrl) {
+
+		private boolean hasChanged() {
+			return !Objects.equals(oldUrl, newUrl) || !Objects.equals(oldOptimizedUrl, newOptimizedUrl);
+		}
+
+		private void apply() {
+			photo.updateObjectKeys(newUrl, newOptimizedUrl);
+		}
+
+		private List<String> oldObjectKeys() {
+			LinkedHashSet<String> objectKeys = new LinkedHashSet<>();
+			if (oldUrl != null && !oldUrl.isBlank()) {
+				objectKeys.add(oldUrl);
+			}
+			if (oldOptimizedUrl != null && !oldOptimizedUrl.isBlank()) {
+				objectKeys.add(oldOptimizedUrl);
+			}
+			return List.copyOf(objectKeys);
+		}
+
+		private List<String> newObjectKeys() {
+			LinkedHashSet<String> objectKeys = new LinkedHashSet<>();
+			if (newUrl != null && !newUrl.isBlank()) {
+				objectKeys.add(newUrl);
+			}
+			if (newOptimizedUrl != null && !newOptimizedUrl.isBlank()) {
+				objectKeys.add(newOptimizedUrl);
+			}
+			return List.copyOf(objectKeys);
 		}
 	}
 

--- a/src/main/java/com/pikume/back/diary/domain/Photo.java
+++ b/src/main/java/com/pikume/back/diary/domain/Photo.java
@@ -1,6 +1,7 @@
 package com.pikume.back.diary.domain;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.pikume.back.diary.domain.vo.DiaryPhotoType;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -37,22 +38,36 @@ public class Photo {
 
 	private Integer photoOrder;
 
+	@Enumerated(EnumType.STRING)
+	@Column(name = "source_type", nullable = false)
+	private DiaryPhotoType sourceType;
+
 	@ManyToOne
 	@JoinColumn(name = "diary_id")
 	@JsonBackReference
 	private Diary diary;
 
 	public Photo(Diary diary, String url, Integer photoOrder) {
+		this(diary, url, photoOrder, DiaryPhotoType.USER_IMAGE);
+	}
+
+	public Photo(Diary diary, String url, Integer photoOrder, DiaryPhotoType sourceType) {
 		this.diary = diary;
 		this.url = url;
 		this.represent = false;
 		this.photoOrder = photoOrder;
+		this.sourceType = sourceType == null ? DiaryPhotoType.USER_IMAGE : sourceType;
 		this.optimizationAttemptCount = 0;
 		initializeOptimizationStatus(url);
 	}
 
 	public void updateRepresent(Boolean represent) {
 		this.represent = represent;
+	}
+
+	public void updateObjectKeys(String url, String optimizedUrl) {
+		this.url = url;
+		this.optimizedUrl = optimizedUrl;
 	}
 
 	public String getDisplayUrl() {

--- a/src/main/java/com/pikume/back/global/util/ImagePathToUrlConverter.java
+++ b/src/main/java/com/pikume/back/global/util/ImagePathToUrlConverter.java
@@ -16,45 +16,6 @@ public class ImagePathToUrlConverter {
     }
 
     /**
-     * Diary 이미지 경로를 전체 URL로 변환합니다. (DiaryController 참고)
-     *
-     * @param imagePath DB에 저장된 이미지 경로 (예: "userId/filename.png")
-     * @param requestMetaInfo HttpRequest 정보 (예: scheme="http", domain="localhost", port=8080)
-     * @return 완성된 URL (예: "http://localhost:8080/api/diary/images/userId/filename.png"), 변환 불가 시 빈 문자열
-     */
-    public String diaryImageUrl(String imagePath, RequestMetaInfo requestMetaInfo){
-        if (imagePath == null || imagePath.isEmpty() || requestMetaInfo == null) {
-            // TODO: 기본 이미지 URL 반환 등 예외 처리
-            return "";
-        }
-        return String.format("%s://%s:%d/api/diary/images/%s",
-                requestMetaInfo.scheme(),
-                requestMetaInfo.domain(),
-                requestMetaInfo.port(),
-                imagePath);
-    }
-
-    public String extractImagePathFromUrl(String fullUrl, RequestMetaInfo requestMetaInfo) {
-        if (fullUrl == null || fullUrl.isEmpty() || requestMetaInfo == null) {
-            return "";
-        }
-
-        // 앞부분: "http://localhost:8080/api/diary/images/"
-        String baseUrlPrefix = String.format("%s://%s:%d/api/diary/images/",
-                requestMetaInfo.scheme(),
-                requestMetaInfo.domain(),
-                requestMetaInfo.port());
-
-        if (fullUrl.startsWith(baseUrlPrefix)) {
-            return fullUrl.substring(baseUrlPrefix.length());
-        }
-
-        // 매칭되지 않으면 빈 문자열 반환
-        return "";
-    }
-
-
-    /**
      * Character 이미지 경로를 storage public URL로 변환합니다.
      *
      * @param imagePath DB에 저장된 이미지 경로 (예: "character_image.png")

--- a/src/main/java/com/pikume/back/security/config/SecurityConfig.java
+++ b/src/main/java/com/pikume/back/security/config/SecurityConfig.java
@@ -66,7 +66,6 @@ public class SecurityConfig {
 				"/api/auth/email",
 				"/api/auth/email-domains",
 				"/api/mobile/auth/**",
-				"/api/diary/images/{userId}/{fileName:.+}",
 				"/api/characters/fixed",
 				"/api/search"));
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -66,6 +66,11 @@ storage:
   bucket: ${STORAGE_BUCKET:piku}
   type: ${STORAGE_TYPE:minio} # minio or s3
 
+image:
+  cache:
+    public-cache-control: ${IMAGE_PUBLIC_CACHE_CONTROL:public, max-age=300, s-maxage=1200}
+    private-cache-control: ${IMAGE_PRIVATE_CACHE_CONTROL:private, no-store, max-age=0}
+
 photo:
   optimization:
     enabled: ${PHOTO_OPTIMIZATION_ENABLED:false}

--- a/src/main/resources/db/migration/V9__add_photo_source_type.sql
+++ b/src/main/resources/db/migration/V9__add_photo_source_type.sql
@@ -1,0 +1,12 @@
+-- Store whether a diary photo came from user upload or AI generation.
+-- Existing rows are inferred from diary_image_generation.file_path when possible.
+
+ALTER TABLE photos
+  ADD COLUMN source_type varchar(32) NOT NULL DEFAULT 'USER_IMAGE';
+
+UPDATE photos p
+JOIN diary_image_generation g ON g.file_path = p.url
+SET p.source_type = 'AI_IMAGE';
+
+CREATE INDEX idx_photos_source_type
+ON photos (source_type);

--- a/src/test/java/com/pikume/back/creative/application/service/ImageGenerationServiceTest.java
+++ b/src/test/java/com/pikume/back/creative/application/service/ImageGenerationServiceTest.java
@@ -60,8 +60,9 @@ class ImageGenerationServiceTest {
 			given(generateDiaryIllustrationPort.generate(any()))
 					.willReturn(new GeneratedIllustrationPayload("base64_generated_image", "png"));
 
-			given(creativeImageStoragePort.saveAIPhoto("base64_generated_image", userId, "png")).willReturn("user-1/generated.png");
-			given(creativeImageStoragePort.getPhotoUrl("user-1/generated.png", false)).willReturn("http://url/generated.png");
+			String privateObjectKey = "private/diary-images/ai/ab/cd/generated.png";
+			given(creativeImageStoragePort.saveAIPhoto("base64_generated_image", userId, "png")).willReturn(privateObjectKey);
+			given(creativeImageStoragePort.getPhotoUrl(privateObjectKey, false)).willReturn("http://url/generated.png");
 
 			given(saveGenerationPort.save(any(DiaryImageGeneration.class))).willAnswer(inv -> {
 				DiaryImageGeneration generation = inv.getArgument(0);
@@ -70,7 +71,7 @@ class ImageGenerationServiceTest {
 
 			GeneratedImageResult result = imageGenerationService.generateDiaryImage(content, userId);
 
-			assertThat(result.filePath()).isEqualTo("user-1/generated.png");
+			assertThat(result.filePath()).isEqualTo(privateObjectKey);
 			assertThat(result.imageUrl()).isEqualTo("http://url/generated.png");
 			then(saveGenerationPort).should().save(any(DiaryImageGeneration.class));
 		}

--- a/src/test/java/com/pikume/back/diary/adapter/in/web/DiaryControllerTest.java
+++ b/src/test/java/com/pikume/back/diary/adapter/in/web/DiaryControllerTest.java
@@ -12,7 +12,6 @@ import com.pikume.back.global.config.CustomUserDetails;
 import com.pikume.back.global.dto.RequestMetaInfo;
 import com.pikume.back.global.error.ProblemDetailFactory;
 import com.pikume.back.global.exception.GlobalExceptionHandler;
-import com.pikume.back.global.util.FileUtil;
 import com.pikume.back.global.util.RequestMetaMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,8 +22,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.MediaType;
-import org.springframework.http.ProblemDetail;
-import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -38,7 +35,6 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -65,9 +61,6 @@ class DiaryControllerTest {
 	private GetDiaryGalleryUseCase getDiaryGalleryUseCase;
 
 	@Mock
-	private FileUtil fileUtil;
-
-	@Mock
 	private RequestMetaMapper requestMetaMapper;
 
 	@Mock
@@ -87,7 +80,6 @@ class DiaryControllerTest {
 				getCalendarUseCase,
 				updateDiaryUseCase,
 				getDiaryGalleryUseCase,
-				fileUtil,
 				requestMetaMapper,
 				validator,
 				problemDetailFactory);
@@ -104,21 +96,6 @@ class DiaryControllerTest {
 				.setValidator(mvcValidator)
 				.setCustomArgumentResolvers(new AuthenticationPrincipalResolver())
 				.build();
-	}
-
-	@Test
-	@DisplayName("GET /api/diary/images/{userId}/{filename}는 파일이 없으면 Problem Details를 반환한다")
-	void getFileReturnsProblemDetailWhenImageDoesNotExist() {
-		willThrow(new RuntimeException("missing")).given(fileUtil).loadFileAsResource("user1/missing.png");
-
-		ResponseEntity<?> response = diaryController.getFile("user1", "missing.png");
-
-		assertThat(response.getStatusCode().value()).isEqualTo(404);
-		assertThat(response.getBody()).isInstanceOf(ProblemDetail.class);
-		ProblemDetail problemDetail = (ProblemDetail) response.getBody();
-		assertThat(problemDetail.getType().toString()).isEqualTo("https://api.pikume.com/problems/common/resource-not-found");
-		assertThat(problemDetail.getStatus()).isEqualTo(404);
-		assertThat(problemDetail.getInstance().toString()).isEqualTo("/api/diary/images/user1/missing.png");
 	}
 
 	@Test

--- a/src/test/java/com/pikume/back/diary/adapter/out/storage/MinioPhotoStorageAdapterTest.java
+++ b/src/test/java/com/pikume/back/diary/adapter/out/storage/MinioPhotoStorageAdapterTest.java
@@ -1,6 +1,10 @@
 package com.pikume.back.diary.adapter.out.storage;
 
 import com.pikume.back.diary.application.port.out.SaveDiaryPort;
+import com.pikume.back.diary.adapter.out.cache.ImageCacheProperties;
+import com.pikume.back.diary.domain.Diary;
+import com.pikume.back.diary.domain.vo.DiaryPhotoType;
+import com.pikume.back.diary.domain.vo.DiaryVisibility;
 import com.pikume.back.global.dto.UploadedFileData;
 import com.pikume.back.global.storage.StorageProperties;
 import com.pikume.back.global.util.FileUtil;
@@ -20,8 +24,10 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.core.ResponseBytes;
 
+import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -39,6 +45,8 @@ class MinioPhotoStorageAdapterTest {
 	private static final String ACCESS_KEY = "test-access-key";
 	private static final String SECRET_KEY = "test-secret-key";
 	private static final String BUCKET = "piku";
+	private static final String PUBLIC_CACHE_CONTROL = "public, max-age=300, s-maxage=1200";
+	private static final String PRIVATE_CACHE_CONTROL = "private, no-store, max-age=0";
 
 	@Mock
 	private S3Client s3Client;
@@ -95,13 +103,25 @@ class MinioPhotoStorageAdapterTest {
 				"http://minio:9000",
 				"http://localhost:19000");
 
-		String url = adapter.getPhotoUrl("user-1/generated.png", false);
+		String url = adapter.getPhotoUrl("private/diary-images/ai/ab/cd/generated.png", false);
 
 		assertThat(url).isNotNull();
 		assertThat(URI.create(url).getHost()).isEqualTo("localhost");
 		assertThat(URI.create(url).getPort()).isEqualTo(19000);
-		assertThat(url).contains("/piku/user-1/generated.png");
+		assertThat(url).contains("/piku/private/diary-images/ai/ab/cd/generated.png");
 		assertThat(url).contains("X-Amz-Signature=");
+	}
+
+	@Test
+	@DisplayName("URL 공개 여부는 호출 인자가 아니라 object key prefix로 판단한다")
+	void determinesPublicUrlByObjectKeyPrefix() {
+		MinioPhotoStorageAdapter adapter = adapterWith(
+				"http://minio:9000",
+				"https://assets.example.com");
+
+		String url = adapter.getPhotoUrl("public/diary-images/user/ab/cd/cover.png", false);
+
+		assertThat(url).isEqualTo("https://assets.example.com/piku/public/diary-images/user/ab/cd/cover.png");
 	}
 
 	@Test
@@ -135,8 +155,8 @@ class MinioPhotoStorageAdapterTest {
 	}
 
 	@Test
-	@DisplayName("public WebP 객체 저장 시 cache-control을 지정한다")
-	void storesPublicWebpObjectWithCacheControl() {
+	@DisplayName("public WebP 객체 저장 시 앱 기본 public cache-control을 지정한다")
+	void storesPublicWebpObjectWithDefaultCacheControl() {
 		MinioPhotoStorageAdapter adapter = adapterWith(
 				"http://minio:9000",
 				"https://assets.example.com");
@@ -144,14 +164,76 @@ class MinioPhotoStorageAdapterTest {
 
 		String storedKey = adapter.storeObject(
 				webp,
-				"public/user-1/photo.webp",
-				"public, max-age=31536000, immutable");
+				"public/diary-images/user/ab/cd/photo.webp",
+				null);
 
-		assertThat(storedKey).isEqualTo("public/user-1/photo.webp");
+		assertThat(storedKey).isEqualTo("public/diary-images/user/ab/cd/photo.webp");
 		then(s3Client).should().putObject(putObjectWithKeyAndCacheControl(
-				"public/user-1/photo.webp",
+				"public/diary-images/user/ab/cd/photo.webp",
 				"image/webp",
-				"public, max-age=31536000, immutable"), any(software.amazon.awssdk.core.sync.RequestBody.class));
+				PUBLIC_CACHE_CONTROL), any(software.amazon.awssdk.core.sync.RequestBody.class));
+	}
+
+	@Test
+	@DisplayName("공개 일기 사용자 이미지는 대표 여부와 무관하게 public sharded key로 저장한다")
+	void savesPublicDiaryUserPhotoUnderPublicShard() throws IOException {
+		MinioPhotoStorageAdapter adapter = adapterWith(
+				"http://minio:9000",
+				"https://assets.example.com");
+		Diary diary = new Diary("내용", DiaryVisibility.PUBLIC, LocalDate.now(), "user-1");
+		UploadedFileData image = new UploadedFileData("photo.png", "image/png", "image".getBytes(StandardCharsets.UTF_8));
+		String objectKey = "public/diary-images/user/ab/cd/photo.png";
+		given(photoUtil.generateDiaryUserImageObjectKey(true, "photo.png")).willReturn(objectKey);
+
+		adapter.savePhoto(diary, image, "user-1", 1);
+
+		then(s3Client).should().putObject(
+				putObjectWithKeyAndCacheControl(objectKey, "image/png", PUBLIC_CACHE_CONTROL),
+				any(software.amazon.awssdk.core.sync.RequestBody.class));
+		then(saveDiaryPort).should().savePhoto(argThat(photo -> objectKey.equals(photo.getUrl())
+				&& !Boolean.TRUE.equals(photo.getRepresent())
+				&& photo.getSourceType() == DiaryPhotoType.USER_IMAGE));
+	}
+
+	@Test
+	@DisplayName("비공개 일기 대표 이미지는 private sharded key로 저장한다")
+	void savesPrivateDiaryRepresentPhotoUnderPrivateShard() throws IOException {
+		MinioPhotoStorageAdapter adapter = adapterWith(
+				"http://minio:9000",
+				"https://assets.example.com");
+		Diary diary = new Diary("내용", DiaryVisibility.PRIVATE, LocalDate.now(), "user-1");
+		UploadedFileData image = new UploadedFileData("photo.png", "image/png", "image".getBytes(StandardCharsets.UTF_8));
+		String objectKey = "private/diary-images/user/ab/cd/photo.png";
+		given(photoUtil.generateDiaryUserImageObjectKey(false, "photo.png")).willReturn(objectKey);
+
+		adapter.savePhoto(diary, image, "user-1", 0);
+
+		then(s3Client).should().putObject(
+				putObjectWithKeyAndCacheControl(objectKey, "image/png", PRIVATE_CACHE_CONTROL),
+				any(software.amazon.awssdk.core.sync.RequestBody.class));
+		then(saveDiaryPort).should().savePhoto(argThat(photo -> objectKey.equals(photo.getUrl())
+				&& Boolean.TRUE.equals(photo.getRepresent())
+				&& photo.getSourceType() == DiaryPhotoType.USER_IMAGE));
+	}
+
+	@Test
+	@DisplayName("AI 임시 이미지는 private sharded key로 저장한다")
+	void savesAiTemporaryPhotoUnderPrivateShard() {
+		MinioPhotoStorageAdapter adapter = adapterWith(
+				"http://minio:9000",
+				"https://assets.example.com");
+		String objectKey = "private/diary-images/ai/ab/cd/generated.png";
+		given(fileUtil.cleanExtension("png")).willReturn("png");
+		given(fileUtil.decodeBase64("base64")).willReturn("image".getBytes(StandardCharsets.UTF_8));
+		given(fileUtil.getContentType("png")).willReturn("image/png");
+		given(photoUtil.generateDiaryAiImageObjectKey("png")).willReturn(objectKey);
+
+		String result = adapter.saveAIPhoto("base64", "user-1", "png");
+
+		assertThat(result).isEqualTo(objectKey);
+		then(s3Client).should().putObject(
+				putObjectWithKeyAndCacheControl(objectKey, "image/png", PRIVATE_CACHE_CONTROL),
+				any(software.amazon.awssdk.core.sync.RequestBody.class));
 	}
 
 	@Test
@@ -160,9 +242,12 @@ class MinioPhotoStorageAdapterTest {
 		MinioPhotoStorageAdapter adapter = adapterWith(
 				"http://minio:9000",
 				"https://assets.example.com");
-		HeadObjectResponse headObjectResponse = HeadObjectResponse.builder().build();
+		HeadObjectResponse headObjectResponse = HeadObjectResponse.builder()
+				.contentType("image/png")
+				.build();
 
-		given(s3Client.headObject(headObjectWithKey("public/private/ai.png")))
+		given(photoUtil.publicObjectKeyFor("private/ai.png")).willReturn("public/ai.png");
+		given(s3Client.headObject(headObjectWithKey("public/ai.png")))
 				.willThrow(S3Exception.builder().statusCode(404).message("Not Found").build())
 				.willReturn(headObjectResponse);
 		given(s3Client.headObject(headObjectWithKey("private/ai.png")))
@@ -170,9 +255,44 @@ class MinioPhotoStorageAdapterTest {
 
 		String movedKey = adapter.moveToPublic("private/ai.png");
 
-		assertThat(movedKey).isEqualTo("public/private/ai.png");
-		then(s3Client).should().copyObject(copyObjectFromTo("private/ai.png", "public/private/ai.png"));
+		assertThat(movedKey).isEqualTo("public/ai.png");
+		then(s3Client).should().copyObject(copyObjectFromToWithCacheControl(
+				"private/ai.png",
+				"public/ai.png",
+				PUBLIC_CACHE_CONTROL,
+				"image/png"));
 		then(s3Client).should().deleteObject(deleteObjectWithKey("private/ai.png"));
+	}
+
+	@Test
+	@DisplayName("private scope로 복사할 때 no-store cache-control을 지정한다")
+	void copiesSourceObjectToPrivateScopeWithNoStoreCacheControl() {
+		MinioPhotoStorageAdapter adapter = adapterWith(
+				"http://minio:9000",
+				"https://assets.example.com");
+		HeadObjectResponse headObjectResponse = HeadObjectResponse.builder()
+				.contentType("image/jpeg")
+				.build();
+
+		given(photoUtil.visibilityObjectKeyFor("public/diary-images/user/ab/cd/photo.jpg", false, DiaryPhotoType.USER_IMAGE))
+				.willReturn("private/diary-images/user/ab/cd/photo.jpg");
+		given(s3Client.headObject(headObjectWithKey("private/diary-images/user/ab/cd/photo.jpg")))
+				.willThrow(S3Exception.builder().statusCode(404).message("Not Found").build())
+				.willReturn(headObjectResponse);
+		given(s3Client.headObject(headObjectWithKey("public/diary-images/user/ab/cd/photo.jpg")))
+				.willReturn(headObjectResponse);
+
+		String copiedKey = adapter.copyToVisibilityScope(
+				"public/diary-images/user/ab/cd/photo.jpg",
+				DiaryVisibility.PRIVATE,
+				DiaryPhotoType.USER_IMAGE);
+
+		assertThat(copiedKey).isEqualTo("private/diary-images/user/ab/cd/photo.jpg");
+		then(s3Client).should().copyObject(copyObjectFromToWithCacheControl(
+				"public/diary-images/user/ab/cd/photo.jpg",
+				"private/diary-images/user/ab/cd/photo.jpg",
+				PRIVATE_CACHE_CONTROL,
+				"image/jpeg"));
 	}
 
 	@Test
@@ -182,14 +302,15 @@ class MinioPhotoStorageAdapterTest {
 				"http://minio:9000",
 				"https://assets.example.com");
 
-		given(s3Client.headObject(headObjectWithKey("public/private/ai.png")))
+		given(photoUtil.publicObjectKeyFor("private/ai.png")).willReturn("public/ai.png");
+		given(s3Client.headObject(headObjectWithKey("public/ai.png")))
 				.willThrow(S3Exception.builder().statusCode(404).message("Not Found").build());
 		given(s3Client.headObject(headObjectWithKey("private/ai.png")))
 				.willThrow(S3Exception.builder().statusCode(403).message("Forbidden").build());
 
 		assertThatThrownBy(() -> adapter.moveToPublic("private/ai.png"))
 				.isInstanceOf(RuntimeException.class)
-				.hasMessageContaining("파일 이동 중 오류가 발생했습니다.")
+				.hasMessageContaining("파일 복제 중 오류가 발생했습니다.")
 				.hasCauseInstanceOf(S3Exception.class);
 
 		then(s3Client).should(never()).copyObject(any(CopyObjectRequest.class));
@@ -203,14 +324,15 @@ class MinioPhotoStorageAdapterTest {
 				"http://minio:9000",
 				"https://assets.example.com");
 
-		given(s3Client.headObject(headObjectWithKey("public/private/ai.png")))
+		given(photoUtil.publicObjectKeyFor("private/ai.png")).willReturn("public/ai.png");
+		given(s3Client.headObject(headObjectWithKey("public/ai.png")))
 				.willThrow(S3Exception.builder().statusCode(404).message("Not Found").build());
 		given(s3Client.headObject(headObjectWithKey("private/ai.png")))
 				.willThrow(S3Exception.builder().statusCode(404).message("Not Found").build());
 
 		assertThatThrownBy(() -> adapter.moveToPublic("private/ai.png"))
 				.isInstanceOf(RuntimeException.class)
-				.hasMessageContaining("파일 이동 중 오류가 발생했습니다.")
+				.hasMessageContaining("파일 복제 중 오류가 발생했습니다.")
 				.hasRootCauseMessage("소스 파일을 찾을 수 없습니다: private/ai.png");
 
 		then(s3Client).should(never()).copyObject(any(CopyObjectRequest.class));
@@ -225,7 +347,8 @@ class MinioPhotoStorageAdapterTest {
 				"https://assets.example.com");
 		HeadObjectResponse headObjectResponse = HeadObjectResponse.builder().build();
 
-		given(s3Client.headObject(headObjectWithKey("public/private/ai.png")))
+		given(photoUtil.publicObjectKeyFor("private/ai.png")).willReturn("public/ai.png");
+		given(s3Client.headObject(headObjectWithKey("public/ai.png")))
 				.willThrow(S3Exception.builder().statusCode(404).message("Not Found").build())
 				.willThrow(S3Exception.builder().statusCode(403).message("Forbidden").build())
 				.willThrow(S3Exception.builder().statusCode(403).message("Forbidden").build());
@@ -234,7 +357,7 @@ class MinioPhotoStorageAdapterTest {
 
 		assertThatThrownBy(() -> adapter.moveToPublic("private/ai.png"))
 				.isInstanceOf(RuntimeException.class)
-				.hasMessageContaining("파일 이동 중 오류가 발생했습니다.")
+				.hasMessageContaining("파일 복제 중 오류가 발생했습니다.")
 				.hasCauseInstanceOf(S3Exception.class);
 	}
 
@@ -247,17 +370,24 @@ class MinioPhotoStorageAdapterTest {
 				ACCESS_KEY,
 				SECRET_KEY,
 				BUCKET);
-		return new MinioPhotoStorageAdapter(s3Client, photoUtil, saveDiaryPort, properties, fileUtil);
+		return new MinioPhotoStorageAdapter(s3Client, photoUtil, saveDiaryPort, properties, new ImageCacheProperties(), fileUtil);
 	}
 
 	private HeadObjectRequest headObjectWithKey(String key) {
 		return argThat((HeadObjectRequest request) -> request != null && key.equals(request.key()));
 	}
 
-	private CopyObjectRequest copyObjectFromTo(String sourceKey, String destinationKey) {
+	private CopyObjectRequest copyObjectFromToWithCacheControl(
+			String sourceKey,
+			String destinationKey,
+			String cacheControl,
+			String contentType) {
 		return argThat((CopyObjectRequest request) -> request != null
 				&& sourceKey.equals(request.sourceKey())
-				&& destinationKey.equals(request.destinationKey()));
+				&& destinationKey.equals(request.destinationKey())
+				&& cacheControl.equals(request.cacheControl())
+				&& contentType.equals(request.contentType())
+				&& request.metadataDirective() == software.amazon.awssdk.services.s3.model.MetadataDirective.REPLACE);
 	}
 
 	private GetObjectRequest getObjectWithKey(String key) {

--- a/src/test/java/com/pikume/back/diary/adapter/out/storage/PhotoUtilTest.java
+++ b/src/test/java/com/pikume/back/diary/adapter/out/storage/PhotoUtilTest.java
@@ -1,0 +1,37 @@
+package com.pikume.back.diary.adapter.out.storage;
+
+import com.pikume.back.diary.domain.vo.DiaryPhotoType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("PhotoUtil")
+class PhotoUtilTest {
+
+	private final PhotoUtil photoUtil = new PhotoUtil();
+
+	@Test
+	@DisplayName("legacy userId 기반 object key는 새 visibility scope로 옮길 때 userId 없는 shard key로 변환한다")
+	void convertsLegacyUserObjectKeyToAnonymousShardKey() {
+		String result = photoUtil.visibilityObjectKeyFor(
+				"public/user-1/photo.jpg",
+				false,
+				DiaryPhotoType.USER_IMAGE);
+
+		assertThat(result).startsWith("private/diary-images/user/");
+		assertThat(result).endsWith(".jpg");
+		assertThat(result).doesNotContain("user-1");
+	}
+
+	@Test
+	@DisplayName("새 diary image object key는 visibility prefix만 변경한다")
+	void swapsVisibilityPrefixForNewDiaryImageObjectKey() {
+		String result = photoUtil.visibilityObjectKeyFor(
+				"private/diary-images/ai/ab/cd/image.png",
+				true,
+				DiaryPhotoType.AI_IMAGE);
+
+		assertThat(result).isEqualTo("public/diary-images/ai/ab/cd/image.png");
+	}
+}

--- a/src/test/java/com/pikume/back/diary/application/service/DiaryCommandServiceTest.java
+++ b/src/test/java/com/pikume/back/diary/application/service/DiaryCommandServiceTest.java
@@ -24,8 +24,10 @@ import com.pikume.back.diary.application.port.out.PhotoStoragePort;
 import com.pikume.back.diary.application.port.out.SaveDiaryPort;
 import com.pikume.back.diary.application.port.out.SendDiaryNotificationPort;
 import com.pikume.back.diary.domain.Diary;
+import com.pikume.back.diary.domain.Photo;
 import com.pikume.back.diary.application.exception.DiaryAccessDeniedException;
 import com.pikume.back.diary.application.exception.DiaryErrorCode;
+import com.pikume.back.diary.application.exception.DiaryImageRelocationException;
 import com.pikume.back.diary.application.exception.DiaryInvalidRequestException;
 import com.pikume.back.diary.application.exception.DiaryNotFoundException;
 import com.pikume.back.diary.application.exception.DuplicateDiaryException;
@@ -42,12 +44,14 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.never;
@@ -151,8 +155,9 @@ class DiaryCommandServiceTest {
 			given(loadCreativePort.existsByIdAndUserId(100L, USER_ID)).willReturn(true);
 			given(saveDiaryPort.save(any(Diary.class))).willAnswer(inv -> inv.getArgument(0));
 			given(loadCreativePort.findById(100L))
-					.willReturn(new DiaryImageGenerationView(100L, USER_ID, "prompt", "ai/image.png", null));
-			given(photoStoragePort.moveToPublic("ai/image.png")).willReturn("public/image.png");
+					.willReturn(new DiaryImageGenerationView(100L, USER_ID, "prompt", "private/diary-images/ai/ab/cd/image.png", null));
+			given(photoStoragePort.moveToPublic("private/diary-images/ai/ab/cd/image.png"))
+					.willReturn("public/diary-images/ai/ab/cd/image.png");
 
 			DiaryCreatedResult result = diaryCommandService.createDiary(diaryCommand, null, USER_ID, requestMetaInfo);
 
@@ -372,6 +377,96 @@ class DiaryCommandServiceTest {
 		}
 
 		@Test
+		@DisplayName("private에서 public으로 변경하면 사진을 public scope로 복제하고 DB key를 갱신한다")
+		void relocatesPhotosWhenChangingFromPrivateToPublic() {
+			Diary diary = new Diary("수정 전", DiaryVisibility.PRIVATE, LocalDate.now(), USER_ID);
+			ReflectionTestUtils.setField(diary, "id", 1L);
+			Photo photo = new Photo(diary, "private/diary-images/user/aa/bb/photo.jpg", 0, DiaryPhotoType.USER_IMAGE);
+			photo.markOptimizationSucceeded("private/diary-images/user/aa/bb/photo.webp");
+			given(loadDiaryPort.findById(1L)).willReturn(Optional.of(diary));
+			given(loadDiaryPort.findPhotosByDiaryIds(Set.of(1L))).willReturn(List.of(photo));
+			given(photoStoragePort.copyToVisibilityScope(
+					"private/diary-images/user/aa/bb/photo.jpg",
+					DiaryVisibility.PUBLIC,
+					DiaryPhotoType.USER_IMAGE))
+					.willReturn("public/diary-images/user/aa/bb/photo.jpg");
+			given(photoStoragePort.copyToVisibilityScope(
+					"private/diary-images/user/aa/bb/photo.webp",
+					DiaryVisibility.PUBLIC,
+					DiaryPhotoType.USER_IMAGE))
+					.willReturn("public/diary-images/user/aa/bb/photo.webp");
+			given(saveDiaryPort.save(diary)).willReturn(diary);
+
+			DiaryUpdatedResult result = diaryCommandService.updateDiary(
+					1L,
+					new UpdateDiaryCommand(DiaryVisibility.PUBLIC, "수정 후"),
+					USER_ID);
+
+			assertThat(result.status()).isEqualTo(DiaryVisibility.PUBLIC);
+			assertThat(photo.getUrl()).isEqualTo("public/diary-images/user/aa/bb/photo.jpg");
+			assertThat(photo.getOptimizedUrl()).isEqualTo("public/diary-images/user/aa/bb/photo.webp");
+			then(saveDiaryPort).should().savePhoto(photo);
+			then(photoStoragePort).should().deleteObject("private/diary-images/user/aa/bb/photo.jpg");
+			then(photoStoragePort).should().deleteObject("private/diary-images/user/aa/bb/photo.webp");
+		}
+
+		@Test
+		@DisplayName("public에서 private으로 변경하면 private object로 복제하고 DB 갱신 후 old public object를 삭제한다")
+		void relocatesPhotosWhenChangingFromPublicToPrivate() {
+			Diary diary = new Diary("수정 전", DiaryVisibility.PUBLIC, LocalDate.now(), USER_ID);
+			ReflectionTestUtils.setField(diary, "id", 1L);
+			Photo photo = new Photo(diary, "public/diary-images/user/aa/bb/photo.jpg", 0, DiaryPhotoType.USER_IMAGE);
+			given(loadDiaryPort.findById(1L)).willReturn(Optional.of(diary));
+			given(loadDiaryPort.findPhotosByDiaryIds(Set.of(1L))).willReturn(List.of(photo));
+			given(photoStoragePort.copyToVisibilityScope(
+					"public/diary-images/user/aa/bb/photo.jpg",
+					DiaryVisibility.PRIVATE,
+					DiaryPhotoType.USER_IMAGE))
+					.willReturn("private/diary-images/user/aa/bb/photo.jpg");
+			given(saveDiaryPort.save(diary)).willReturn(diary);
+
+			DiaryUpdatedResult result = diaryCommandService.updateDiary(
+					1L,
+					new UpdateDiaryCommand(DiaryVisibility.PRIVATE, "수정 후"),
+					USER_ID);
+
+			assertThat(result.status()).isEqualTo(DiaryVisibility.PRIVATE);
+			assertThat(diary.getStatus()).isEqualTo(DiaryVisibility.PRIVATE);
+			assertThat(photo.getUrl()).isEqualTo("private/diary-images/user/aa/bb/photo.jpg");
+			then(saveDiaryPort).should().savePhoto(photo);
+			then(saveDiaryPort).should().save(diary);
+			then(photoStoragePort).should().deleteObject("public/diary-images/user/aa/bb/photo.jpg");
+		}
+
+		@Test
+		@DisplayName("DB 갱신 후 old object 삭제에 실패해도 공개범위 변경 결과는 반환한다")
+		void succeedsWhenOldObjectCleanupFailsAfterDbUpdate() {
+			Diary diary = new Diary("수정 전", DiaryVisibility.PRIVATE, LocalDate.now(), USER_ID);
+			ReflectionTestUtils.setField(diary, "id", 1L);
+			Photo photo = new Photo(diary, "private/diary-images/user/aa/bb/photo.jpg", 0, DiaryPhotoType.USER_IMAGE);
+			given(loadDiaryPort.findById(1L)).willReturn(Optional.of(diary));
+			given(loadDiaryPort.findPhotosByDiaryIds(Set.of(1L))).willReturn(List.of(photo));
+			given(photoStoragePort.copyToVisibilityScope(
+					"private/diary-images/user/aa/bb/photo.jpg",
+					DiaryVisibility.PUBLIC,
+					DiaryPhotoType.USER_IMAGE))
+					.willReturn("public/diary-images/user/aa/bb/photo.jpg");
+			willThrow(new RuntimeException("delete failed"))
+					.given(photoStoragePort)
+					.deleteObject("private/diary-images/user/aa/bb/photo.jpg");
+			given(saveDiaryPort.save(diary)).willReturn(diary);
+
+			DiaryUpdatedResult result = diaryCommandService.updateDiary(
+					1L,
+					new UpdateDiaryCommand(DiaryVisibility.PUBLIC, "수정 후"),
+					USER_ID);
+
+			assertThat(result.status()).isEqualTo(DiaryVisibility.PUBLIC);
+			assertThat(photo.getUrl()).isEqualTo("public/diary-images/user/aa/bb/photo.jpg");
+			then(saveDiaryPort).should().save(diary);
+		}
+
+		@Test
 		@DisplayName("메타데이터 분석 실패해도 일기 수정은 성공한다")
 		void succeedsEvenIfAnalysisFails() {
 			Diary diary = new Diary("수정 전", DiaryVisibility.PRIVATE, LocalDate.now(), USER_ID);
@@ -496,8 +591,8 @@ class DiaryCommandServiceTest {
 	class SaveAiPhoto {
 
 		@Test
-		@DisplayName("대표 사진(order=0)이면 public으로 이동한다")
-		void movesToPublicWhenRepresent() {
+		@DisplayName("공개 일기이면 AI 사진을 public으로 이동한다")
+		void movesToPublicWhenDiaryIsPublic() {
 			Diary diary = new Diary("내용", DiaryVisibility.PUBLIC, LocalDate.now(), USER_ID);
 			given(loadCreativePort.findById(1L))
 					.willReturn(new DiaryImageGenerationView(1L, USER_ID, "prompt", "private/ai.png", null));
@@ -507,19 +602,19 @@ class DiaryCommandServiceTest {
 
 			then(photoStoragePort).should().moveToPublic("private/ai.png");
 			then(loadCreativePort).should().updateFilePath(1L, "public/ai.png");
-			then(saveDiaryPort).should().savePhoto(any());
+			then(saveDiaryPort).should().savePhoto(argThat(photo -> photo.getSourceType() == DiaryPhotoType.AI_IMAGE));
 		}
 
 		@Test
-		@DisplayName("대표 사진이 아니면 public으로 이동하지 않는다")
-		void doesNotMoveWhenNotRepresent() {
-			Diary diary = new Diary("내용", DiaryVisibility.PUBLIC, LocalDate.now(), USER_ID);
+		@DisplayName("비공개 일기이면 AI 사진을 private 경로로 유지한다")
+		void keepsPrivateWhenDiaryIsPrivate() {
+			Diary diary = new Diary("내용", DiaryVisibility.PRIVATE, LocalDate.now(), USER_ID);
 			given(loadCreativePort.findById(1L))
 					.willReturn(new DiaryImageGenerationView(1L, USER_ID, "prompt", "private/ai.png", null));
 			diaryCommandService.saveAiPhoto(diary, 1L, USER_ID, 1);
 
 			then(photoStoragePort).should(never()).moveToPublic(any());
-			then(saveDiaryPort).should().savePhoto(any());
+			then(saveDiaryPort).should().savePhoto(argThat(photo -> photo.getSourceType() == DiaryPhotoType.AI_IMAGE));
 		}
 
 		@Test

--- a/src/test/java/com/pikume/back/feed/application/service/FeedQueryServiceQueryIntegrationTest.java
+++ b/src/test/java/com/pikume/back/feed/application/service/FeedQueryServiceQueryIntegrationTest.java
@@ -1,11 +1,5 @@
 package com.pikume.back.feed.application.service;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import jakarta.persistence.EntityManager;
 import com.pikume.back.diary.adapter.out.persistence.DiaryJpaRepository;
 import com.pikume.back.diary.adapter.out.persistence.PhotoJpaRepository;
 import com.pikume.back.diary.domain.Diary;
@@ -28,6 +22,12 @@ import com.pikume.back.social.domain.like.Like;
 import com.pikume.back.testsupport.AbstractJpaQueryCountIntegrationTest;
 import com.pikume.back.user.adapter.out.persistence.UserJpaRepository;
 import com.pikume.back.user.domain.User;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/src/test/java/com/pikume/back/feed/application/service/FeedQueryServiceQueryIntegrationTest.java
+++ b/src/test/java/com/pikume/back/feed/application/service/FeedQueryServiceQueryIntegrationTest.java
@@ -8,7 +8,6 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import jakarta.persistence.EntityManager;
 import com.pikume.back.diary.adapter.out.persistence.DiaryJpaRepository;
 import com.pikume.back.diary.adapter.out.persistence.PhotoJpaRepository;
-import com.pikume.back.diary.adapter.out.storage.PhotoConstants;
 import com.pikume.back.diary.domain.Diary;
 import com.pikume.back.diary.domain.Photo;
 import com.pikume.back.diary.domain.vo.DiaryVisibility;
@@ -82,7 +81,7 @@ class FeedQueryServiceQueryIntegrationTest extends AbstractJpaQueryCountIntegrat
 	private Diary publicLow;
 	private Diary nonFriendFriendsDiary;
 
-	@BeforeEach
+    @BeforeEach
 	void setUp() {
 		LocalDateTime baseTime = LocalDateTime.of(2026, 3, 8, 12, 0);
 
@@ -305,7 +304,8 @@ class FeedQueryServiceQueryIntegrationTest extends AbstractJpaQueryCountIntegrat
 	}
 
 	private void saveRepresentPhoto(Diary diary, String fileName) {
-		Photo photo = new Photo(diary, PhotoConstants.PUBLIC_PREFIX + diary.getUserId() + "/" + fileName, 0);
+        String PUBLIC_PREFIX = "public/";
+        Photo photo = new Photo(diary, PUBLIC_PREFIX + diary.getUserId() + "/" + fileName, 0);
 		photo.updateRepresent(true);
 		photoJpaRepository.save(photo);
 	}

--- a/src/test/java/com/pikume/back/notification/application/service/NotificationServiceQueryIntegrationTest.java
+++ b/src/test/java/com/pikume/back/notification/application/service/NotificationServiceQueryIntegrationTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import com.pikume.back.diary.adapter.out.persistence.DiaryJpaRepository;
 import com.pikume.back.diary.adapter.out.persistence.PhotoJpaRepository;
-import com.pikume.back.diary.adapter.out.storage.PhotoConstants;
 import com.pikume.back.diary.domain.Diary;
 import com.pikume.back.diary.domain.Photo;
 import com.pikume.back.diary.domain.vo.DiaryVisibility;
@@ -81,7 +80,7 @@ class NotificationServiceQueryIntegrationTest extends AbstractJpaQueryCountInteg
 	}
 
 	private void saveRepresentPhoto(Diary diary, String fileName) {
-		Photo photo = new Photo(diary, PhotoConstants.PUBLIC_PREFIX + diary.getUserId() + "/" + fileName, 0);
+		Photo photo = new Photo(diary, "public/" + diary.getUserId() + "/" + fileName, 0);
 		photo.updateRepresent(true);
 		photoJpaRepository.save(photo);
 	}


### PR DESCRIPTION
이미지 정책을 public/private scope로 사용자의 식별값을 기준으로 구분했으나 익명일기에서 사용자가 특정되는 현상이 발생
이미지 저장 정책을 변경
[Diary Image Storage Runbook](https://github.com/pikume/piku-back/blob/b5561ed086458fc389610aeaf5a63a83bdf68ffc/docs/runbooks/diary-image-storage-runbook.md) 참고